### PR TITLE
Relax minor version in dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
 install:
   - npm install
   - pip install .[dependencies]
-  - pip install .[tests]
   - pip install dash[dev]
+  - pip install .[tests]
   - pip install dash[testing]
   - wget https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - npm install
   - pip install .[dependencies]
   - pip install .[tests]
+  - pip install dash[dev]
   - pip install dash[testing]
   - wget https://chromedriver.storage.googleapis.com/76.0.3809.12/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you have selected install_dependencies during the prompt, you can skip this p
 3. Install python packages required to build components.
     ```
     pip install .[dependencies]
+    pip install dash[dev]
     ```
 4. Install the python packages for testing (optional)
     ```

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join('webviz_core_components', 'package-info.json')) as f:
 package_name = package['name'].replace(' ', '_').replace('-', '_')
 
 install_requires = [
-    'dash~=1.0.1'
+    'dash~=1.1'
 ]
 
 tests_require = [
@@ -21,7 +21,8 @@ tests_require = [
     'percy',
     'selenium',
     'flake8',
-    'pylint'
+    'pylint',
+    'dash-core-components'
 ]
 
 # 'dash[testing]' to be added in tests_require when

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'tests': tests_require,
         'dependencies': install_requires
     },
-    setup_requires=['setuptools_scm>=3.2.0'],
+    setup_requires=['setuptools_scm~=3.2'],
     use_scm_version=True,
     classifiers=[
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,7 @@ tests_require = [
     'percy',
     'selenium',
     'flake8',
-    'pylint',
-    'dash-core-components'
+    'pylint'
 ]
 
 # 'dash[testing]' to be added in tests_require when


### PR DESCRIPTION
Currently some requirements versions are given as `~= x.y.z`. This increases likelihood of version conflicts. Assuming dependencies are well behaving with respect to semantic versioning, it is better to state `~= x.y` in order to reduce risk of verson conflict. 

See [PEP 440](https://www.python.org/dev/peps/pep-0440/#compatible-release) for more information on compatible version specifiers.