### PR TITLE
Travis git tag release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
   - pip install --upgrade pip
 
 install:
-  - export GIT_TAG=$(git describe --tags)
   - npm install
   - pip install .[dependencies]
   - pip install dash[dev]

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - pip install --upgrade pip
 
 install:
+  - export GIT_TAG=$(git describe --tags)
   - npm install
   - pip install .[dependencies]
   - pip install dash[dev]
@@ -31,6 +32,11 @@ script:
   - pip install .
   - pytest
 
+before_deploy:
+  # Set the version tag back to what was sent from the git release
+  # This changed locally due to local building of the code
+  - git tag --delete $(git tag --list)
+  - git tag $GIT_TAG
 deploy:
   - provider: pypi
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
 before_deploy:
   # Set the version back to what was sent from the git release.
   # This changed locally due to local building of the code.
-- export SETUPTOOLS_SCM_PRETEND_VERSION=$TRAVIS_TAG
+  - export SETUPTOOLS_SCM_PRETEND_VERSION=$TRAVIS_TAG
 deploy:
   - provider: pypi
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,9 @@ script:
   - pytest
 
 before_deploy:
-  # Set the version tag back to what was sent from the git release
-  # This changed locally due to local building of the code
-  - git tag --delete $(git tag --list)
-  - git tag $GIT_TAG
+  # Set the version back to what was sent from the git release.
+  # This changed locally due to local building of the code.
+- export SETUPTOOLS_SCM_PRETEND_VERSION=$TRAVIS_TAG
 deploy:
   - provider: pypi
     skip_cleanup: true


### PR DESCRIPTION
On git code release, the tag is sent to Travis. However, since artifacts are built on Travis before release, the git tag automatically changes to a `dev` tag locally.

Therefore: After building of the artifacts, set tag back to what was sent from git initially on release, and use that when deploying to pypi.