### PR TITLE
Load dev bundle only in dev mode

### DIFF
--- a/webviz_core_components/__init__.py
+++ b/webviz_core_components/__init__.py
@@ -47,10 +47,7 @@ _this_module = _sys.modules[__name__]
 _js_dist = [
     {
         'relative_package_path': 'webviz_core_components.min.js',
-        'namespace': package_name
-    },
-    {
-        'relative_package_path': 'webviz_core_components.dev.js',
+        'dev_package_path': 'webviz_core_components.dev.js',
         'namespace': package_name
     },
     {


### PR DESCRIPTION
Currently, both the `dev` and the `min` bundle is loaded when `webviz_core_components` is used. Change this to the correct Dash configuration such that `dev` only loads when `Dash/Flask` starts in dev mode.

Tested that `min` only loads when running with `debug=False`.