### PR TITLE
Remove inspect deprecation warning

### DIFF
--- a/webviz_core_components/graph.py
+++ b/webviz_core_components/graph.py
@@ -18,7 +18,7 @@ class Graph(dcc.Graph):
 
     def __init__(self, *args, **kwargs):
 
-        config_arg_index = inspect.getargspec(dcc.Graph).args.index('config')
+        config_arg_index = inspect.getfullargspec(dcc.Graph).args.index('config')
 
         if len(args) > config_arg_index:  # config given as positional argument
             args = args[:config_arg_index] + \


### PR DESCRIPTION
See https://docs.python.org/3.6/library/inspect.html#inspect.getargspec. 

> Deprecated since version 3.0: Use getfullargspec() for an updated API that is usually a drop-in replacement, but also correctly handles function annotations and keyword-only parameters.