### PR TITLE
Remove + in scm version tag as it breaks Dash's new fingerprint system

### DIFF
--- a/webviz_core_components/__init__.py
+++ b/webviz_core_components/__init__.py
@@ -22,7 +22,11 @@ except ModuleNotFoundError:
     pass
 
 try:
-    __version__ = get_distribution(__name__).version
+    # Dash fingerprint system does not work with +. E.g. a development version tag like
+    # 0.0.10.dev11+abcd1234.d20191103 will break Dash's fingerprint system.
+    # Need to replace + with some supporter character as long as
+    # https://github.com/plotly/dash/issues/995 is open.
+    __version__ = get_distribution(__name__).version.replace("+", ".")
 except DistributionNotFound:
     # package is not installed
     pass

--- a/webviz_core_components/__init__.py
+++ b/webviz_core_components/__init__.py
@@ -24,7 +24,7 @@ except ModuleNotFoundError:
 try:
     # Dash fingerprint system does not work with +. E.g. a development version tag like
     # 0.0.10.dev11+abcd1234.d20191103 will break Dash's fingerprint system.
-    # Need to replace + with some supporter character as long as
+    # Need to replace + with some supported character as long as
     # https://github.com/plotly/dash/issues/995 is open.
     __version__ = get_distribution(__name__).version.replace("+", ".")
 except DistributionNotFound:


### PR DESCRIPTION
Development tags in SCM versions has a `+` which breaks the new fingerprint system in `dash >= 1.5` (Dash  currently replace `.` with `_`, bot not other characters like `+`, see [this line](https://github.com/plotly/dash/blob/40b5357f262ac207f94ac980e6cb928d94df65b7/dash/fingerprint.py#L12)). We can solve this downstream in `webviz` by doing the replacement ourselves.