### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ this package has a side effect of changing the Plotly distribution coming with
 that do not rely on [`eval()`](https://developer.chrome.com/extensions/contentSecurityPolicy#relaxing-eval).
 More specifically it changes from `plotly-full` to `plotly-cartesian` bundle. This will be
 necessary in order to enforce a strong CSP configuration as long as
-[this `plotly` issue](https://github.com/plotly/plotly.js/issues/897) and
-[this `dash-core-components` issue](https://github.com/plotly/dash-core-components/issues/462)
-both are open. Note that this side-effect only takes place if `dash-core-components`
+[this `plotly` issue](https://github.com/plotly/plotly.js/issues/897) is open.
+Note that this side-effect only takes place if `dash-core-components`
 is installed, which is a requirement if the `Graph` component from this repository
 is going to be used.
 

--- a/webviz_core_components/graph.py
+++ b/webviz_core_components/graph.py
@@ -5,11 +5,6 @@ import dash_core_components as dcc
 # dash-core-components provide their own plotly javascript bundle,
 # which is not needed since webviz-core-components does the same
 # (however a smaller plotly bundle without the `eval` function)
-#
-# The whole webviz_core_components.Graph component is only necessary as
-# long as https://github.com/plotly/dash-core-components/issues/462 is
-# open. When that is closed, changing default plotly variables can be
-# done purely in Python by inheriting from `dcc.Graph`.
 
 dcc._js_dist = [
     js for js in dcc._js_dist if not js["relative_package_path"].startswith("plotly-")


### PR DESCRIPTION
One of the dash-core-components issues is now closed, while the solution is not attractive to webviz-config, i.e. probably leave the implementation of `Graph` as it is, and remove the mentioning of the issue in the readme.