### PR TITLE
Update html2canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4910,9 +4910,9 @@
             "dev": true
         },
         "html2canvas": {
-            "version": "1.0.0-rc.5",
-            "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-rc.5.tgz",
-            "integrity": "sha512-DtNqPxJNXPoTajs+lVQzGS1SULRI4GQaROeU5R41xH8acffHukxRh/NBVcTBsfCkJSkLq91rih5TpbEwUP9yWA==",
+            "version": "1.0.0-rc.7",
+            "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-rc.7.tgz",
+            "integrity": "sha512-yvPNZGejB2KOyKleZspjK/NruXVQuowu8NnV2HYG7gW7ytzl+umffbtUI62v2dCHQLDdsK6HIDtyJZ0W3neerA==",
             "requires": {
                 "css-line-break": "1.1.1"
             }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.21",
         "@fortawesome/free-solid-svg-icons": "^5.10.1",
         "@fortawesome/react-fontawesome": "^0.1.4",
-        "html2canvas": "^1.0.0-rc.5",
+        "html2canvas": "^1.0.0-rc.7",
         "ramda": "^0.26.1",
         "react-colorscales": "^0.7.3",
         "reactour": "^1.15.2",


### PR DESCRIPTION
Relates to #56.

This dep. bump does not solve the font issue (that is a bigger problem - related to the fact that svg/img can not use external resources when rendering to canvas), but it solves a separate, related issue: Styles set in SVGs with external stylesheets are now included correctly in rendered images.