### PR TITLE
Support scrolled window when taking snapshot

### DIFF
--- a/src/lib/components/WebvizPluginPlaceholder.react.js
+++ b/src/lib/components/WebvizPluginPlaceholder.react.js
@@ -83,7 +83,11 @@ export default class WebvizPluginPlaceholder extends Component {
                                 tooltip="Take screenshot"
                                 onClick={() =>
                                     html2canvas(
-                                        document.getElementById(this.props.id)
+                                        document.getElementById(this.props.id),
+                                        {
+                                            scrollX: -window.scrollX,
+                                            scrollY: -window.scrollY,
+                                        }                                        
                                     ).then(canvas =>
                                         canvas.toBlob(blob =>
                                             download_file({


### PR DESCRIPTION
Closes #74.

Apparently `html2canvas` needs to be told the current scroll position, and don't do this automatically. Not sure why this is not default behavior, but adding `scrollX` and `scrollY` as input `html2canvas` seems to correctly create a canvas of given element even when the window has been scrolled (otherwise it clips it incorrectly).

All configuration options listed here: https://html2canvas.hertzen.com/configuration.