### PR TITLE
Remove 'toImage' from default 'modeBarButtonsToRemove'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [#114](https://github.com/equinor/webviz-core-components/pull/114) - Better alignment of tooltips with icons and pointer cursor when hovering buttons in `WebvizPluginPlaceholder`.
+- [#118](https://github.com/equinor/webviz-core-components/pull/118) - Remove `toImage` from default `modeBarButtonsToRemove` in `wcc.Graph`.
 
 ### Fixed
 - [#114](https://github.com/equinor/webviz-core-components/pull/114) - Fixed bug in `WebvizPluginPlaceholder` preventing tooltips from being shown.

--- a/webviz_core_components/graph.py
+++ b/webviz_core_components/graph.py
@@ -26,7 +26,7 @@ class Graph(dcc.Graph):
             config = input_config.copy()
 
         if "modeBarButtonsToRemove" not in config:
-            config["modeBarButtonsToRemove"] = ["sendDataToCloud", "toImage"]
+            config["modeBarButtonsToRemove"] = ["sendDataToCloud"]
 
         if "displaylogo" not in config:
             config["displaylogo"] = False


### PR DESCRIPTION
Closes #78. The `toImage` button allows user to take "screenshots" of individual plots - not only the whole plugin/dashboard.