### PR TITLE
Made single node selection more obvious

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#130](https://github.com/equinor/webviz-core-components/pull/130) - Added feedback button to `WebvizPluginPlaceholder`. Added `href` and `target` properties to `WebvizToolbarButton`.
 
+### Changed
+- [#121](https://github.com/equinor/webviz-core-components/pull/121) - Changed rendering of `SmartNodeSelector` component when only one node can be selected.
+
 ### Fixed
 - [#124](https://github.com/equinor/webviz-core-components/pull/124) - `SmartNodeSelector` now returns all selected tags (also invalid and duplicate ones) to parent.
 - [#123](https://github.com/equinor/webviz-core-components/pull/123) - Removed unused variables and added types to `SmartNodeSelector` and its tests.

--- a/src/lib/components/SmartNodeSelector/components/SmartNodeSelector.css
+++ b/src/lib/components/SmartNodeSelector/components/SmartNodeSelector.css
@@ -45,6 +45,12 @@
     min-width: 200px;
 }
 
+.SmartNodeSelector--frameless {
+    border: 0;
+    padding: 0;
+    padding-right: 40px;
+}
+
 .SmartNodeSelector--Invalid {
     border: 1px #eb0000 solid !IMPORTANT;
 }
@@ -164,6 +170,7 @@
 
 .SmartNodeSelector__InnerTag {
     display: flex;
+    flex: 1;
     border-radius: 4px;
     background-color: #fefefe;
     white-space: nowrap;

--- a/src/lib/components/SmartNodeSelector/components/SmartNodeSelectorComponent.tsx
+++ b/src/lib/components/SmartNodeSelector/components/SmartNodeSelectorComponent.tsx
@@ -1040,7 +1040,11 @@ export default class SmartNodeSelectorComponent extends Component<SmartNodeSelec
                     onClick={(e) => this.selectLastInput(e)}
                     onMouseDown={(e) => this.handleMouseDown(e)}
                 >
-                    <ul className="SmartNodeSelector__Tags" ref={this.tagFieldRef} style={frameless ? { width: "100%" } : {}}>
+                    <ul
+                        className="SmartNodeSelector__Tags"
+                        ref={this.tagFieldRef}
+                        style={frameless ? { width: "100%" } : {}}
+                    >
                         {nodeSelections.map((selection, index) => (
                             <Tag
                                 key={`${index}`}

--- a/src/lib/components/SmartNodeSelector/components/SmartNodeSelectorComponent.tsx
+++ b/src/lib/components/SmartNodeSelector/components/SmartNodeSelectorComponent.tsx
@@ -606,15 +606,17 @@ export default class SmartNodeSelectorComponent extends Component<SmartNodeSelec
     }
 
     markTagsAsSelected(startIndex: number, endIndex: number): void {
-        this.state.nodeSelections.map((nodeSelection, index) => {
-            if (index >= startIndex && index <= endIndex) {
-                nodeSelection.setSelected(true);
-            }
-            else {
-                nodeSelection.setSelected(false);
-            }
-        });
-        this.updateState({ forceUpdate: true });
+        if (this.props.maxNumSelectedNodes !== 1) {
+            this.state.nodeSelections.map((nodeSelection, index) => {
+                if (index >= startIndex && index <= endIndex) {
+                    nodeSelection.setSelected(true);
+                }
+                else {
+                    nodeSelection.setSelected(false);
+                }
+            });
+            this.updateState({ forceUpdate: true });
+        }
     }
 
     unselectAllTags({
@@ -1023,11 +1025,14 @@ export default class SmartNodeSelectorComponent extends Component<SmartNodeSelec
             )
         }
 
+        const frameless = maxNumSelectedNodes === 1;
+
         return (
             <div id={id} ref={this.ref}>
                 {label && <label>{label}</label>}
                 <div className={classNames({
                     "SmartNodeSelector": true,
+                    "SmartNodeSelector--frameless": frameless,
                     "SmartNodeSelector--SuggestionsActive": suggestionsVisible,
                     "SmartNodeSelector--Invalid":
                         (maxNumSelectedNodes > 0 && this.countValidSelections() > maxNumSelectedNodes)
@@ -1035,11 +1040,12 @@ export default class SmartNodeSelectorComponent extends Component<SmartNodeSelec
                     onClick={(e) => this.selectLastInput(e)}
                     onMouseDown={(e) => this.handleMouseDown(e)}
                 >
-                    <ul className="SmartNodeSelector__Tags" ref={this.tagFieldRef}>
+                    <ul className="SmartNodeSelector__Tags" ref={this.tagFieldRef} style={frameless ? { width: "100%" } : {}}>
                         {nodeSelections.map((selection, index) => (
                             <Tag
                                 key={`${index}`}
                                 index={index}
+                                frameless={frameless}
                                 placeholder={placeholder ? placeholder : "Add new tag"}
                                 treeNodeSelection={selection}
                                 countTags={this.countTags()}
@@ -1075,7 +1081,7 @@ export default class SmartNodeSelectorComponent extends Component<SmartNodeSelec
                         />
                     }
                 </div>
-                {maxNumSelectedNodes > 0 && <div className={classNames({
+                {maxNumSelectedNodes > 1 && <div className={classNames({
                     "SmartNodeSelector__NumberOfTags": true,
                     "SmartNodeSelector__Error": this.countValidSelections() > maxNumSelectedNodes
                 })} ref={this.refNumberOfTags}>Selected {this.countValidSelections()} of {maxNumSelectedNodes}</div>}

--- a/src/lib/components/SmartNodeSelector/components/Tag.tsx
+++ b/src/lib/components/SmartNodeSelector/components/Tag.tsx
@@ -294,14 +294,14 @@ export default class Tag extends Component<TagProps> {
         }
     }
 
-    private makeStyle(): object {
+    private makeStyle(): { [key: string]: string | number } {
         const {
             treeNodeSelection,
             frameless,
         } = this.props;
 
         const colors = treeNodeSelection.colors();
-        const style: object = {};
+        const style = {};
 
         if (colors.length >= 2) {
             style["background"] = `linear-gradient(to left, ${colors.join(", ")}) border-box`;

--- a/tests/js/__snapshots__/SmartNodeSelector.test.tsx.snap
+++ b/tests/js/__snapshots__/SmartNodeSelector.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`SmartNodeSelector Renders correctly (compare to snapshot in ./__snapsho
               <input
                 placeholder="Add new tag..."
                 spellcheck="false"
-                style="width: 50px;"
+                style="width: 100px;"
                 type="text"
                 value=""
               />


### PR DESCRIPTION
Before, when allowing only a single node to be selected, the selector was still rendered as if several nodes could be selected. This was using unnecessary much space and could be confusing for the user. This PR makes the single node selection more obvious by changing how the selector is rendered.