### PR TITLE
Fixed not working download function in `WebvizPluginPlaceholder` and added test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 ### Fixed
+- [#122](https://github.com/equinor/webviz-core-components/pull/122) - Fixed bug in `WebvizPluginPlaceholder` preventing download button from working. Added tests for `WebvizPluginPlaceholder`.
 - [#120](https://github.com/equinor/webviz-core-components/pull/120) - Multiple bug fixes (deletion of currently selected tag not possible; state not dynamically updated;
 empty or invalid node names no longer allowed; auto resizing not working when initializing tag component) and new tests for these bugs. Also removed unnecessary properties.
 

--- a/src/lib/components/WebvizPluginPlaceholder/WebvizPluginPlaceholder.tsx
+++ b/src/lib/components/WebvizPluginPlaceholder/WebvizPluginPlaceholder.tsx
@@ -59,15 +59,6 @@ const InnerWebvizPluginPlaceholder = (
 
     useEffect(() => {
         if (didMountRef.current) {
-            if (download !== null && download !== undefined) {
-                downloadFile({
-                    filename: download.filename,
-                    data: download.content,
-                    mimeType: download.mime_type
-                });
-                setProps({ download: null });
-            }
-
             // Hide/show body scrollbar depending on plugin going in/out of full screen mode.
             if (prevExpandedRef.current !== expanded) {
                 document.body.style.overflow = expanded
@@ -79,8 +70,27 @@ const InnerWebvizPluginPlaceholder = (
         else {
             didMountRef.current = true;
         }
+    }, [prevExpandedRef]);
+
+    useEffect(() => {
         showDeprecationWarnings();
     }, []);
+
+    useEffect(() => {
+        if (didMountRef.current) {
+            if (download !== null && download !== undefined) {
+                downloadFile({
+                    filename: download.filename,
+                    data: download.content,
+                    mimeType: download.mime_type
+                });
+                setProps({ download: null });
+            }
+        }
+        else {
+            didMountRef.current = true;
+        }
+    }, [download]);
 
     const showDeprecationWarnings = () => {
         for (const warning of deprecation_warnings) {
@@ -89,10 +99,10 @@ const InnerWebvizPluginPlaceholder = (
                 {
                     variant: "warning",
                     action: (
-                        <a 
-                            className="webviz-config-plugin-deprecation-link" 
-                            href={warning.url} 
-                            target="_blank" 
+                        <a
+                            className="webviz-config-plugin-deprecation-link"
+                            href={warning.url}
+                            target="_blank"
                             rel="noopener noreferrer"
                         >
                             More info
@@ -148,13 +158,15 @@ const InnerWebvizPluginPlaceholder = (
                                             scrollY: -window.scrollY,
                                         }
                                     ).then(canvas =>
-                                        canvas.toBlob(blob =>
-                                            downloadFile({
-                                                filename: screenshot_filename,
-                                                data: blob,
-                                                mimeType: "image/png"
-                                            })
-                                        )
+                                        canvas.toBlob(blob => {
+                                            if (blob !== null) {
+                                                downloadFile({
+                                                    filename: screenshot_filename,
+                                                    data: blob,
+                                                    mimeType: "image/png"
+                                                })
+                                            }
+                                        })
                                     )
                             }
                             }

--- a/src/lib/components/WebvizPluginPlaceholder/utils/downloadFile.ts
+++ b/src/lib/components/WebvizPluginPlaceholder/utils/downloadFile.ts
@@ -12,7 +12,7 @@ export default function downloadFile(
         mimeType
     }: {
         filename: string,
-        data: Blob | null,
+        data: Blob | string,
         mimeType: string
     }
 ): void {

--- a/tests/js/WebvizPluginPlaceholder.test.tsx
+++ b/tests/js/WebvizPluginPlaceholder.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WebvizPluginPlaceholder } from '../../src/lib';
+import { WebvizPluginPlaceholderInteractiveContainer } from './WebvizPluginPlaceholderInteractiveContainer';
+
+export type PropType = {
+    data_requested?: number;
+};
+
+
+const renderWebvizPluginPlaceholder = (
+): RenderResult => {
+    const steps = [
+        {
+            selector: "#blue-rect",
+            content: "This is my first step",
+        },
+        {
+            selector: "#green-rect",
+            content: "This is my second step",
+        },
+    ];
+    return render(
+        <WebvizPluginPlaceholder
+            id="WebvizPluginPlaceholder"
+            tour_steps={steps}
+            setProps={() => { return; }}
+            deprecation_warnings={
+                [
+                    {
+                        message: "Deprecated 1",
+                        url: "https://github.com/equinor/webviz-core-components"
+                    },
+                    {
+                        message: "Deprecated 2",
+                        url: "https://github.com/equinor/webviz-core-components"
+                    }
+                ]
+            }
+        />
+    );
+}
+
+const renderInteractiveWebvizPluginPlaceholder = (): RenderResult => {
+    return render(<WebvizPluginPlaceholderInteractiveContainer />);
+};
+
+describe('WebvizPluginPlaceholder', () => {
+
+    it('Renders correctly (compare to snapshot in ./__snapshots__/WebvizPluginPlaceholder.test.tsx.snap)', () => {
+        const { container } = renderWebvizPluginPlaceholder();
+        expect(container).toMatchSnapshot();
+    });
+
+    it('Data is downloaded correctly', () => {
+        const { container } = renderInteractiveWebvizPluginPlaceholder();
+
+        const link = document.createElement("a");
+
+        jest.spyOn(document, "createElement").mockImplementationOnce(() => link);
+
+        expect(container).toBeDefined();
+
+        const button = container.querySelectorAll(".webviz-config-plugin-button")[2] as HTMLElement;
+        expect(button).toBeDefined();
+
+        userEvent.click(button);
+
+        expect(link.href).toEqual('data:application/txt;base64,test');
+        expect(link.download).toEqual("test.txt");
+        jest.spyOn(document, "createElement").mockRestore();
+    });
+
+});

--- a/tests/js/WebvizPluginPlaceholderInteractiveContainer.tsx
+++ b/tests/js/WebvizPluginPlaceholderInteractiveContainer.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { WebvizPluginPlaceholder } from '../../src/lib';
+import { PropType } from './WebvizPluginPlaceholder.test';
+
+
+export const WebvizPluginPlaceholderInteractiveContainer: React.FC = (): JSX.Element => {
+    const [download, setDownload] = React.useState(undefined);
+
+    const steps = [
+        {
+            selector: "#blue-rect",
+            content: "This is my first step",
+        },
+        {
+            selector: "#green-rect",
+            content: "This is my second step",
+        },
+    ];
+
+    const setProps = (props: PropType): void => {
+        if (props.data_requested) {
+            setDownload({
+                filename: "test.txt",
+                content: "test",
+                mime_type: "application/txt"
+            });
+        }
+    };
+
+    return (
+        <WebvizPluginPlaceholder
+            id="WebvizPluginPlaceholder"
+            tour_steps={steps}
+            setProps={setProps}
+            download={download}
+        />
+    )
+};
+
+WebvizPluginPlaceholderInteractiveContainer.propTypes = {
+    data_requested: PropTypes.number
+};

--- a/tests/js/__snapshots__/WebvizPluginPlaceholder.test.tsx.snap
+++ b/tests/js/__snapshots__/WebvizPluginPlaceholder.test.tsx.snap
@@ -1,0 +1,258 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WebvizPluginPlaceholder Renders correctly (compare to snapshot in ./__snapshots__/WebvizPluginPlaceholder.test.tsx.snap) 1`] = `
+<div>
+  <div
+    class="webviz-config-plugin-wrapper"
+  >
+    <div
+      class="webviz-plugin-content"
+      id="WebvizPluginPlaceholder"
+    >
+      <div
+        class="webviz-plugin-content-overlay"
+        id="overlayWebvizPluginPlaceholder"
+        style="display: none;"
+      >
+        <div
+          class="webviz-plugin-data-owner"
+        />
+      </div>
+    </div>
+    <div
+      class="webviz-config-plugin-buttonbar"
+    >
+      <div
+        class="webviz-config-tooltip-wrapper"
+      >
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-camera-retro fa-w-16 webviz-config-plugin-button"
+          data-icon="camera-retro"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M48 32C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48H48zm0 32h106c3.3 0 6 2.7 6 6v20c0 3.3-2.7 6-6 6H38c-3.3 0-6-2.7-6-6V80c0-8.8 7.2-16 16-16zm426 96H38c-3.3 0-6-2.7-6-6v-36c0-3.3 2.7-6 6-6h138l30.2-45.3c1.1-1.7 3-2.7 5-2.7H464c8.8 0 16 7.2 16 16v74c0 3.3-2.7 6-6 6zM256 424c-66.2 0-120-53.8-120-120s53.8-120 120-120 120 53.8 120 120-53.8 120-120 120zm0-208c-48.5 0-88 39.5-88 88s39.5 88 88 88 88-39.5 88-88-39.5-88-88-88zm-48 104c-8.8 0-16-7.2-16-16 0-35.3 28.7-64 64-64 8.8 0 16 7.2 16 16s-7.2 16-16 16c-17.6 0-32 14.4-32 32 0 8.8-7.2 16-16 16z"
+            fill="currentColor"
+          />
+        </svg>
+        <div
+          class="webviz-config-tooltip"
+        >
+          Take screenshot
+        </div>
+      </div>
+      <div
+        class="webviz-config-tooltip-wrapper"
+      >
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-expand fa-w-14 webviz-config-plugin-button"
+          data-icon="expand"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 448 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0 180V56c0-13.3 10.7-24 24-24h124c6.6 0 12 5.4 12 12v40c0 6.6-5.4 12-12 12H64v84c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12zM288 44v40c0 6.6 5.4 12 12 12h84v84c0 6.6 5.4 12 12 12h40c6.6 0 12-5.4 12-12V56c0-13.3-10.7-24-24-24H300c-6.6 0-12 5.4-12 12zm148 276h-40c-6.6 0-12 5.4-12 12v84h-84c-6.6 0-12 5.4-12 12v40c0 6.6 5.4 12 12 12h124c13.3 0 24-10.7 24-24V332c0-6.6-5.4-12-12-12zM160 468v-40c0-6.6-5.4-12-12-12H64v-84c0-6.6-5.4-12-12-12H12c-6.6 0-12 5.4-12 12v124c0 13.3 10.7 24 24 24h124c6.6 0 12-5.4 12-12z"
+            fill="currentColor"
+          />
+        </svg>
+        <div
+          class="webviz-config-tooltip"
+        >
+          Expand
+        </div>
+      </div>
+      <div
+        class="webviz-config-tooltip-wrapper"
+      >
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-download fa-w-16 webviz-config-plugin-button"
+          data-icon="download"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M216 0h80c13.3 0 24 10.7 24 24v168h87.7c17.8 0 26.7 21.5 14.1 34.1L269.7 378.3c-7.5 7.5-19.8 7.5-27.3 0L90.1 226.1c-12.6-12.6-3.7-34.1 14.1-34.1H192V24c0-13.3 10.7-24 24-24zm296 376v112c0 13.3-10.7 24-24 24H24c-13.3 0-24-10.7-24-24V376c0-13.3 10.7-24 24-24h146.7l49 49c20.1 20.1 52.5 20.1 72.6 0l49-49H488c13.3 0 24 10.7 24 24zm-124 88c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20zm64 0c0-11-9-20-20-20s-20 9-20 20 9 20 20 20 20-9 20-20z"
+            fill="currentColor"
+          />
+        </svg>
+        <div
+          class="webviz-config-tooltip"
+        >
+          Download data
+        </div>
+      </div>
+      <div
+        class="webviz-config-tooltip-wrapper"
+      >
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-question-circle fa-w-16 webviz-config-plugin-button"
+          data-icon="question-circle"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 512 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"
+            fill="currentColor"
+          />
+        </svg>
+        <div
+          class="webviz-config-tooltip"
+        >
+          Guided tour
+        </div>
+      </div>
+      <div
+        class="webviz-config-tooltip-wrapper"
+      >
+        <svg
+          aria-hidden="true"
+          class="svg-inline--fa fa-exclamation-triangle fa-w-18 webviz-config-plugin-button webviz-config-plugin-button-important"
+          data-icon="exclamation-triangle"
+          data-prefix="fas"
+          focusable="false"
+          role="img"
+          viewBox="0 0 576 512"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+            fill="currentColor"
+          />
+        </svg>
+        <div
+          class="webviz-config-tooltip"
+        >
+          This plugin has deprecation warnings
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="makeStyles-root-1 makeStyles-bottom-5 makeStyles-right-9 makeStyles-bottom-5 makeStyles-right-9 makeStyles-reverseColumns-2"
+  >
+    <div
+      class="MuiCollapse-container SnackbarItem-collapseContainer-28 MuiCollapse-entered"
+      style="min-height: 0px;"
+    >
+      <div
+        class="MuiCollapse-wrapper SnackbarItem-collapseWrapper-29"
+      >
+        <div
+          class="MuiCollapse-wrapperInner SnackbarItem-collapseWrapperInner-31"
+        >
+          <div
+            class="SnackbarItem-root-12 SnackbarItem-wrappedRoot-27 SnackbarItem-anchorOriginBottomRight-16"
+          >
+            <div
+              aria-describedby="notistack-snackbar"
+              class="ForwardRef-root-32 SnackbarItem-contentRoot-24 SnackbarItem-variantWarning-23 SnackbarItem-lessPadding-19"
+              role="alert"
+              style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
+            >
+              <div
+                class="SnackbarItem-message-25"
+                id="notistack-snackbar"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  style="font-size: 20px; margin-inline-end: 8px;"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M13,14H11V10H13M13,18H11V16H13M1,21H23L12,2L1,21Z"
+                  />
+                </svg>
+                Deprecated 1
+              </div>
+              <div
+                class="SnackbarItem-action-26"
+              >
+                <a
+                  class="webviz-config-plugin-deprecation-link"
+                  href="https://github.com/equinor/webviz-core-components"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  More info
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiCollapse-container SnackbarItem-collapseContainer-28 MuiCollapse-entered"
+      style="min-height: 0px;"
+    >
+      <div
+        class="MuiCollapse-wrapper SnackbarItem-collapseWrapper-29"
+      >
+        <div
+          class="MuiCollapse-wrapperInner SnackbarItem-collapseWrapperInner-31"
+        >
+          <div
+            class="SnackbarItem-root-12 SnackbarItem-wrappedRoot-27 SnackbarItem-anchorOriginBottomRight-16"
+          >
+            <div
+              aria-describedby="notistack-snackbar"
+              class="ForwardRef-root-32 SnackbarItem-contentRoot-24 SnackbarItem-variantWarning-23 SnackbarItem-lessPadding-19"
+              role="alert"
+              style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
+            >
+              <div
+                class="SnackbarItem-message-25"
+                id="notistack-snackbar"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  style="font-size: 20px; margin-inline-end: 8px;"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M13,14H11V10H13M13,18H11V16H13M1,21H23L12,2L1,21Z"
+                  />
+                </svg>
+                Deprecated 2
+              </div>
+              <div
+                class="SnackbarItem-action-26"
+              >
+                <a
+                  class="webviz-config-plugin-deprecation-link"
+                  href="https://github.com/equinor/webviz-core-components"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  More info
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Clicking on the download button in the `WebvizPluginPlaceholder` component did not have any effect. This bug is fixed with this PR. In addition, a test was added to make sure this functionality does not break again in future releases.