### PR TITLE
All tags (also invalid or duplicate ones, but no empty strings) are send to parent in `SmartNodeSelector`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 ### Fixed
+- [#124](https://github.com/equinor/webviz-core-components/pull/124) - `SmartNodeSelector` now returns all selected tags (also invalid and duplicate ones) to parent.
 - [#123](https://github.com/equinor/webviz-core-components/pull/123) - Removed unused variables and added types to `SmartNodeSelector` and its tests.
 
 ## [0.4.1] - 2021-05-04

--- a/src/lib/components/SmartNodeSelector/components/SmartNodeSelectorComponent.tsx
+++ b/src/lib/components/SmartNodeSelector/components/SmartNodeSelectorComponent.tsx
@@ -774,7 +774,9 @@ export default class SmartNodeSelectorComponent extends Component<SmartNodeSelec
         loop1:
         for (let i = 0; i < this.countTags(); i++) {
             const nodeSelection = this.nodeSelection(i);
-            selectedTags.push(nodeSelection.getCompleteNodePathAsString());
+            if (nodeSelection.getCompleteNodePathAsString() !== "") {
+                selectedTags.push(nodeSelection.getCompleteNodePathAsString());
+            }
             if (nodeSelection.isValid() && !this.checkIfSelectionIsDuplicate(nodeSelection, i)) {
                 const matchedNodePaths = nodeSelection.exactlyMatchedNodePaths();
                 for (let j = 0; j < matchedNodePaths.length; j++) {

--- a/src/lib/components/SmartNodeSelector/components/SmartNodeSelectorComponent.tsx
+++ b/src/lib/components/SmartNodeSelector/components/SmartNodeSelectorComponent.tsx
@@ -774,9 +774,9 @@ export default class SmartNodeSelectorComponent extends Component<SmartNodeSelec
         loop1:
         for (let i = 0; i < this.countTags(); i++) {
             const nodeSelection = this.nodeSelection(i);
+            selectedTags.push(nodeSelection.getCompleteNodePathAsString());
             if (nodeSelection.isValid() && !this.checkIfSelectionIsDuplicate(nodeSelection, i)) {
                 const matchedNodePaths = nodeSelection.exactlyMatchedNodePaths();
-                selectedTags.push(nodeSelection.getCompleteNodePathAsString());
                 for (let j = 0; j < matchedNodePaths.length; j++) {
                     if (selectedNodes.length >= maxNumSelectedNodes && maxNumSelectedNodes > 0) {
                         break loop1;

--- a/tests/js/SmartNodeSelector.test.tsx
+++ b/tests/js/SmartNodeSelector.test.tsx
@@ -136,6 +136,9 @@ const renderInteractiveSmartNodeSelector = (): RenderResult => {
 };
 
 describe('SmartNodeSelector', () => {
+    afterEach(() => {
+        clearParentProps();
+    });
 
     it('Renders correctly (compare to snapshot in ./__snapshots__/SmartNodeSelector.test.tsx.snap)', () => {
         const { container } = renderSmartNodeSelector(RenderDataStructure.Flat);
@@ -375,8 +378,8 @@ describe('SmartNodeSelector', () => {
         fireEvent.keyDown(lastInput, { key: 'v', ctrlKey: true });
 
 
-        expect(parentProps.selectedTags).toHaveLength(1);
-        expect(parentProps.selectedTags[0]).toMatch("Data");
+        expect(parentProps.selectedTags).toHaveLength(6);
+        expect(parentProps.selectedTags).toEqual(["Data", "Data", "Data", "Data", "Data", "Data"]);
         expect(parentProps.selectedNodes).toHaveLength(1);
         expect(parentProps.selectedNodes[0]).toMatch("Data");
         expect(parentProps.selectedIds).toHaveLength(1);


### PR DESCRIPTION
Before this commit, only valid, non-duplicate tags were sent to the parent component via the `selectedTags` argument in the `setProps` function call. This made it hard for parent components that updated states (and caused rerenderings) based on the `setProps` calls from `SmartNodeSelector` to keep the state of the `SmartNodeSelector`'s selection. For example, a click on the switch button in a tag could select a node which lacks the last sub node of the previous selection, causing the selected node to become invalid. However, the parent's `setProps` function would be called with `selectedTags` missing this now invalidated tag. If the `SmartNodeSelector` component gets rerendered, this invalid selected tag would most likely get lost, causing incomprehensible behaviour. Sending all tags, even invalid ones, but as before only valid nodes and ids should help to overcome this potential problem.