### PR TITLE
Use `next` as `npm publish` tag when prerelease

### DIFF
--- a/.github/workflows/webviz-core-components.yml
+++ b/.github/workflows/webviz-core-components.yml
@@ -69,6 +69,10 @@ jobs:
           npm run test --prefix ./react
           pytest ./tests --headless
 
+      - name: ⏭️ Set next as npm publish tag if prerelease
+        if: github.event.release.prerelease
+        run: echo "NPM_PUBLISH_TAG=next" >> $GITHUB_ENV
+
       - name: 🔼 Build and publish Node.js package
         if: github.event_name == 'release' && matrix.python-version == '3.6'
         env:
@@ -78,7 +82,8 @@ jobs:
           npm version --no-git-tag-version ${GITHUB_REF//refs\/tags\//}
           npm config set '//registry.npmjs.org/:_authToken' '${NPM_TOKEN}'
           npm config set always-auth true
-          npm publish --access public
+          # Use 'latest' tag if $NPM_PUBLISH_TAG is not set:
+          npm publish --access public --tag ${NPM_PUBLISH_TAG:-latest}
 
       - name: 🚢 Build and deploy Python package
         if: github.event_name == 'release' && matrix.python-version == '3.6'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 ### Changed
+- [#134](https://github.com/equinor/webviz-core-components/pull/134) - When prereleases are done in GitHub, they will now be published to `npm` using the `next` tag. E.g. `npm install @webviz/core-components` will install the latest official release, while `npm install @webviz/core-components@next` will install the
+latest prerelease.
 - [#125](https://github.com/equinor/webviz-core-components/pull/125) - Moved `React` code and `Node.js` configuration into `./react/` directory. 
 Adjusted `package.json`, `.gitignore`, `.vscode/launch.js` and GitHub workflow file accordingly.
 - [#125](https://github.com/equinor/webviz-core-components/pull/125) - Tightened `tsconfig` options in order to have a more strict code validation.


### PR DESCRIPTION
Closes #129.