### PR TITLE
Removed `pointer` cursor from `selectors.css`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Changed
+
+- [#191](https://github.com/equinor/webviz-core-components/pull/191) - Removed `pointer` cursor from `webviz-selectors` class.
+
 ## [0.5.3] - 2021-11-08
 
 ### Changed

--- a/react/src/lib/components/Layout/Selectors/selectors.css
+++ b/react/src/lib/components/Layout/Selectors/selectors.css
@@ -1,9 +1,7 @@
 .webviz-selectors {
-    cursor: pointer;
     color: #555;
     margin-top: 0.5vh;
-    margin-bottom: 0.5vh; 
-    
+    margin-bottom: 0.5vh;
 }
 
 .webviz-selectors:hover {


### PR DESCRIPTION
This (marginally) improves the user experience by not showing non-interactive elements as interactive anymore.