### PR TITLE
Implemented wrapper around `MaterialUI's` draggable dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,163 +7,167 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Added
+
+-   [#201](https://github.com/equinor/webviz-core-components/pull/201) - Implemented wrapper around `MaterialUI's` draggable dialog. Makes a new `Dialog` component available in `Dash`.
+
 ## [0.5.5] - 2022-02-09
 
 ### Changed
 
-- [#197](https://github.com/equinor/webviz-core-components/pull/197) - Updated `@equinor/eds-icons` (and associated `@equinor/eds-core-react` dependencies) in order to use new icons upstream in the application menu.
+-   [#197](https://github.com/equinor/webviz-core-components/pull/197) - Updated `@equinor/eds-icons` (and associated `@equinor/eds-core-react` dependencies) in order to use new icons upstream in the application menu.
 
 ## [0.5.4] - 2021-12-09
 
 ### Fixed
 
-- [#178](https://github.com/equinor/webviz-core-components/pull/178) - Bug fixes in `SmartNodeSelector`: Placeholder not applied, text width not calculated correctly initially, jump to next node when pressing `Enter`, bug fixes and improvements when navigating with arrows. Node names containing `-` were breaking the code.
-- [#191](https://github.com/equinor/webviz-core-components/pull/191) - Removed `pointer` cursor from `webviz-selectors` class.
+-   [#178](https://github.com/equinor/webviz-core-components/pull/178) - Bug fixes in `SmartNodeSelector`: Placeholder not applied, text width not calculated correctly initially, jump to next node when pressing `Enter`, bug fixes and improvements when navigating with arrows. Node names containing `-` were breaking the code.
+-   [#191](https://github.com/equinor/webviz-core-components/pull/191) - Removed `pointer` cursor from `webviz-selectors` class.
 
 ### Added
 
-- [#178](https://github.com/equinor/webviz-core-components/pull/178) - Implemented case-insensitive and description search in `SmartNodeSelector`. 
+-   [#178](https://github.com/equinor/webviz-core-components/pull/178) - Implemented case-insensitive and description search in `SmartNodeSelector`.
     Also added export of data types and implemented `OR` operator in nodes as beta feature. Implemented better visual feedback, tab and end/home navigation. Implemented visual feedback and possibility to show all suggestions.
 
 ## [0.5.3] - 2021-11-08
 
 ### Changed
 
-- [#181](https://github.com/equinor/webviz-core-components/pull/181) - `SmartNodeSelector` suggestions window is now attached at top level of DOM tree. This improves usability when used in a scroll area.
+-   [#181](https://github.com/equinor/webviz-core-components/pull/181) - `SmartNodeSelector` suggestions window is now attached at top level of DOM tree. This improves usability when used in a scroll area.
 
 ### Fixed
 
-- [#177](https://github.com/equinor/webviz-core-components/pull/177) - Bug fix: Menu missing if using non-existent icon.
+-   [#177](https://github.com/equinor/webviz-core-components/pull/177) - Bug fix: Menu missing if using non-existent icon.
 
 ### Added
 
-- [#182](https://github.com/equinor/webviz-core-components/pull/182) - Added option to wrap `SelectWithLabel` in a `Details` collapsible widget.
-- [#174](https://github.com/equinor/webviz-core-components/pull/174) - Implemented `initiallyCollapsed` setting for menu.
+-   [#182](https://github.com/equinor/webviz-core-components/pull/182) - Added option to wrap `SelectWithLabel` in a `Details` collapsible widget.
+-   [#174](https://github.com/equinor/webviz-core-components/pull/174) - Implemented `initiallyCollapsed` setting for menu.
 
 ## [0.5.2] - 2021-10-08
 
 ### Changed
 
-- [#161](https://github.com/equinor/webviz-core-components/pull/161) - Updated to `Dash 2.0`.
-- [#173](https://github.com/equinor/webviz-core-components/pull/173) - Improved menu layout and auto-width.
+-   [#161](https://github.com/equinor/webviz-core-components/pull/161) - Updated to `Dash 2.0`.
+-   [#173](https://github.com/equinor/webviz-core-components/pull/173) - Improved menu layout and auto-width.
 
 ### Fixed
 
-- [#157](https://github.com/equinor/webviz-core-components/pull/157) - Added utf8 encoding to Python's `open()` calls.
-- [#158](https://github.com/equinor/webviz-core-components/pull/158) - Fixed error messages when contact person details not provided to `WebvizPluginPlaceholder`.
-- [#159](https://github.com/equinor/webviz-core-components/pull/159) - Call `revokeObjectURL` after using `createObjectURL` in `WebvizPluginPlaceholder`.
-- [#160](https://github.com/equinor/webviz-core-components/pull/160) - Bug fix: `Select` property `value` does not return correct type.
-- [#172](https://github.com/equinor/webviz-core-components/pull/172) - Bug fix: No margin between plugins.
+-   [#157](https://github.com/equinor/webviz-core-components/pull/157) - Added utf8 encoding to Python's `open()` calls.
+-   [#158](https://github.com/equinor/webviz-core-components/pull/158) - Fixed error messages when contact person details not provided to `WebvizPluginPlaceholder`.
+-   [#159](https://github.com/equinor/webviz-core-components/pull/159) - Call `revokeObjectURL` after using `createObjectURL` in `WebvizPluginPlaceholder`.
+-   [#160](https://github.com/equinor/webviz-core-components/pull/160) - Bug fix: `Select` property `value` does not return correct type.
+-   [#172](https://github.com/equinor/webviz-core-components/pull/172) - Bug fix: No margin between plugins.
 
 ### Added
 
-- [#154](https://github.com/equinor/webviz-core-components/pull/154) - Implemented new menu component.
+-   [#154](https://github.com/equinor/webviz-core-components/pull/154) - Implemented new menu component.
 
 ## [0.5.1] - 2021-07-12
 
 ### Changed
 
-- [#140](https://github.com/equinor/webviz-core-components/pull/140) - Improved styling of the `Select` component.
-- [#145](https://github.com/equinor/webviz-core-components/pull/145) - Added wrapper components for typically used Dash components (Dropdown, Slider, etc) with additional styling.
-- [#148](https://github.com/equinor/webviz-core-components/pull/148) - Changed default value of `numSecondsUntilSuggestionsAreShown` to 0.5 in `SmartNodeSelector` component
-- [#150](https://github.com/equinor/webviz-core-components/pull/150) - Changed color of single remove button in `SmartNodeSelector` to the same as for the remove all button.
-- [#151](https://github.com/equinor/webviz-core-components/pull/151) - `SmartNodeSelector`: Changes to `data` and `delimiter` props are considered now and cause the component to update.
+-   [#140](https://github.com/equinor/webviz-core-components/pull/140) - Improved styling of the `Select` component.
+-   [#145](https://github.com/equinor/webviz-core-components/pull/145) - Added wrapper components for typically used Dash components (Dropdown, Slider, etc) with additional styling.
+-   [#148](https://github.com/equinor/webviz-core-components/pull/148) - Changed default value of `numSecondsUntilSuggestionsAreShown` to 0.5 in `SmartNodeSelector` component
+-   [#150](https://github.com/equinor/webviz-core-components/pull/150) - Changed color of single remove button in `SmartNodeSelector` to the same as for the remove all button.
+-   [#151](https://github.com/equinor/webviz-core-components/pull/151) - `SmartNodeSelector`: Changes to `data` and `delimiter` props are considered now and cause the component to update.
 
 ### Added
 
-- [#148](https://github.com/equinor/webviz-core-components/pull/148) - Added `lineBreakAfterTag` property to `SmartNodeSelector` which defaults to false. If set to true, tags are separated by a line break.
+-   [#148](https://github.com/equinor/webviz-core-components/pull/148) - Added `lineBreakAfterTag` property to `SmartNodeSelector` which defaults to false. If set to true, tags are separated by a line break.
 
 ## [0.5.0] - 2021-06-06
 
 ### Changed
 
-- [#134](https://github.com/equinor/webviz-core-components/pull/134) - When prereleases are done in GitHub, they will now be published to `npm` using the `next` tag. E.g. `npm install @webviz/core-components` will install the latest official release, while `npm install @webviz/core-components@next` will install the
+-   [#134](https://github.com/equinor/webviz-core-components/pull/134) - When prereleases are done in GitHub, they will now be published to `npm` using the `next` tag. E.g. `npm install @webviz/core-components` will install the latest official release, while `npm install @webviz/core-components@next` will install the
     latest prerelease.
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Moved `React` code and `Node.js` configuration into `./react/` directory.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Moved `React` code and `Node.js` configuration into `./react/` directory.
     Adjusted `package.json`, `.gitignore`, `.vscode/launch.js` and GitHub workflow file accordingly.
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Tightened `tsconfig` options in order to have a more strict code validation.
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Synchronized ECMA Script version in `tsconfig` and `eslint`.
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added automatic removal of unused autogenerated files (`.Rbuildignore`).
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Removed `plotly-cartesian.js` and `package.json` (top level) from `MANIFEST.in`.
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Adjusted components according to new `tsconfig` options.
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Moved `flexbox.css` into new component folder.
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Introduced `DefaultPropsHelper.ts` in order to account for coexistence of TypeScript restrictions and `React`'s `defaultProps`.
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - `setup.py` is now reading package data from `package.json` file inside `webviz_core_components`.
-- [#121](https://github.com/equinor/webviz-core-components/pull/121) - Changed rendering of `SmartNodeSelector` component when only one node can be selected.
-- [#136](https://github.com/equinor/webviz-core-components/pull/136) - Changes to selected tags in `SmartNodeSelector` are now always sent.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Tightened `tsconfig` options in order to have a more strict code validation.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Synchronized ECMA Script version in `tsconfig` and `eslint`.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added automatic removal of unused autogenerated files (`.Rbuildignore`).
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Removed `plotly-cartesian.js` and `package.json` (top level) from `MANIFEST.in`.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Adjusted components according to new `tsconfig` options.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Moved `flexbox.css` into new component folder.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Introduced `DefaultPropsHelper.ts` in order to account for coexistence of TypeScript restrictions and `React`'s `defaultProps`.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - `setup.py` is now reading package data from `package.json` file inside `webviz_core_components`.
+-   [#121](https://github.com/equinor/webviz-core-components/pull/121) - Changed rendering of `SmartNodeSelector` component when only one node can be selected.
+-   [#136](https://github.com/equinor/webviz-core-components/pull/136) - Changes to selected tags in `SmartNodeSelector` are now always sent.
 
 ### Added
 
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added `Storybook` for demo of components.
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added `declarations.d.ts` file for ambient declarations for npm modules without type declarations.
-- [#130](https://github.com/equinor/webviz-core-components/pull/130) - Added feedback button to `WebvizPluginPlaceholder`. Added `href` and `target` properties to `WebvizToolbarButton`.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added `Storybook` for demo of components.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added `declarations.d.ts` file for ambient declarations for npm modules without type declarations.
+-   [#130](https://github.com/equinor/webviz-core-components/pull/130) - Added feedback button to `WebvizPluginPlaceholder`. Added `href` and `target` properties to `WebvizToolbarButton`.
 
 ### Fixed
 
-- [#136](https://github.com/equinor/webviz-core-components/pull/136) - Several bug fixes in `SmartNodeSelector` (exception on entering invalid node name when no metadata given, exception on using several wildcards,
+-   [#136](https://github.com/equinor/webviz-core-components/pull/136) - Several bug fixes in `SmartNodeSelector` (exception on entering invalid node name when no metadata given, exception on using several wildcards,
     new tag when pressing enter with single node selection and invalid data, node selected several times when its name is partly contained in other nodes, exception on holding backspace pressed).
-- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Removed `selectedNodes` attribute from `SmartNodeSelector` arguments in `usage.py`.
-- [#124](https://github.com/equinor/webviz-core-components/pull/124) - `SmartNodeSelector` now returns all selected tags (also invalid and duplicate ones) to parent.
-- [#123](https://github.com/equinor/webviz-core-components/pull/123) - Removed unused variables and added types to `SmartNodeSelector` and its tests.
+-   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Removed `selectedNodes` attribute from `SmartNodeSelector` arguments in `usage.py`.
+-   [#124](https://github.com/equinor/webviz-core-components/pull/124) - `SmartNodeSelector` now returns all selected tags (also invalid and duplicate ones) to parent.
+-   [#123](https://github.com/equinor/webviz-core-components/pull/123) - Removed unused variables and added types to `SmartNodeSelector` and its tests.
 
 ## [0.4.1] - 2021-05-04
 
 ### Fixed
 
-- [#122](https://github.com/equinor/webviz-core-components/pull/122) - Fixed bug in `WebvizPluginPlaceholder` preventing download button from working. Added tests for `WebvizPluginPlaceholder`.
-- [#120](https://github.com/equinor/webviz-core-components/pull/120) - Multiple bug fixes (deletion of currently selected tag not possible; state not dynamically updated;
+-   [#122](https://github.com/equinor/webviz-core-components/pull/122) - Fixed bug in `WebvizPluginPlaceholder` preventing download button from working. Added tests for `WebvizPluginPlaceholder`.
+-   [#120](https://github.com/equinor/webviz-core-components/pull/120) - Multiple bug fixes (deletion of currently selected tag not possible; state not dynamically updated;
     empty or invalid node names no longer allowed; auto resizing not working when initializing tag component) and new tests for these bugs. Also removed unnecessary properties.
 
 ## [0.4.0] - 2021-04-26
 
 ### Added
 
-- [#114](https://github.com/equinor/webviz-core-components/pull/114) - Added deprecation warning to `WebvizPluginPlaceholder`.
+-   [#114](https://github.com/equinor/webviz-core-components/pull/114) - Added deprecation warning to `WebvizPluginPlaceholder`.
 
 ### Changed
 
-- [#114](https://github.com/equinor/webviz-core-components/pull/114) - Better alignment of tooltips with icons and pointer cursor when hovering buttons in `WebvizPluginPlaceholder`.
-- [#118](https://github.com/equinor/webviz-core-components/pull/118) - Remove `toImage` from default `modeBarButtonsToRemove` in `wcc.Graph`.
+-   [#114](https://github.com/equinor/webviz-core-components/pull/114) - Better alignment of tooltips with icons and pointer cursor when hovering buttons in `WebvizPluginPlaceholder`.
+-   [#118](https://github.com/equinor/webviz-core-components/pull/118) - Remove `toImage` from default `modeBarButtonsToRemove` in `wcc.Graph`.
 
 ### Fixed
 
-- [#114](https://github.com/equinor/webviz-core-components/pull/114) - Fixed bug in `WebvizPluginPlaceholder` preventing tooltips from being shown.
+-   [#114](https://github.com/equinor/webviz-core-components/pull/114) - Fixed bug in `WebvizPluginPlaceholder` preventing tooltips from being shown.
 
 ## [0.3.2] - 2021-04-09
 
-- [#115](https://github.com/equinor/webviz-core-components/pull/115) - Removed postinstall script in order to not having npm trying to copy package.json when installing as npm package.
-- [#113](https://github.com/equinor/webviz-core-components/pull/113) - Fixed LGTM warnings caused by SmartNodeSelector component's defaultProps definitions.
-- [#107](https://github.com/equinor/webviz-core-components/pull/107) - Fixed bug in argument modifier method (when input argument is given as positional).
-- [#107](https://github.com/equinor/webviz-core-components/pull/107) - Prevent false positives through LGTM/GitHub CodeQL.
+-   [#115](https://github.com/equinor/webviz-core-components/pull/115) - Removed postinstall script in order to not having npm trying to copy package.json when installing as npm package.
+-   [#113](https://github.com/equinor/webviz-core-components/pull/113) - Fixed LGTM warnings caused by SmartNodeSelector component's defaultProps definitions.
+-   [#107](https://github.com/equinor/webviz-core-components/pull/107) - Fixed bug in argument modifier method (when input argument is given as positional).
+-   [#107](https://github.com/equinor/webviz-core-components/pull/107) - Prevent false positives through LGTM/GitHub CodeQL.
 
 ## [0.3.1] - 2021-03-28
 
 ### Fixed
 
-- [#105](https://github.com/equinor/webviz-core-components/pull/105) - Fixed bug when updating Select values from a Dash callback.
+-   [#105](https://github.com/equinor/webviz-core-components/pull/105) - Fixed bug when updating Select values from a Dash callback.
 
 ## [0.3.0] - 2021-03-26
 
 ### Fixed
 
-- [#99](https://github.com/equinor/webviz-core-components/pull/99) - Fixed bug which prevented using the download button in `WebvizPluginPlaceholder` and started to download when component was mounting.
+-   [#99](https://github.com/equinor/webviz-core-components/pull/99) - Fixed bug which prevented using the download button in `WebvizPluginPlaceholder` and started to download when component was mounting.
 
 ### Added
 
-- [#96](https://github.com/equinor/webviz-core-components/pull/96) - Added publishing of npm package to Github Workflow
+-   [#96](https://github.com/equinor/webviz-core-components/pull/96) - Added publishing of npm package to Github Workflow
 
 ### Changed
 
-- [#100](https://github.com/equinor/webviz-core-components/pull/100) - Adjusted build environment in order to be able to write
+-   [#100](https://github.com/equinor/webviz-core-components/pull/100) - Adjusted build environment in order to be able to write
     components in TypeScript and to publish to npm. Also changed all components to TypeScript.
 
 ## [0.2.0] - 2021-03-11
 
 ### Changed
 
-- [#86](https://github.com/equinor/webviz-core-components/pull/86) - Refactored and converted code to TypeScript (main component files to JSX), adjusted build environment accordingly and added validation of JS/TS to GitHub workflow
+-   [#86](https://github.com/equinor/webviz-core-components/pull/86) - Refactored and converted code to TypeScript (main component files to JSX), adjusted build environment accordingly and added validation of JS/TS to GitHub workflow
 
 ### Added
 
-- [#87](https://github.com/equinor/webviz-core-components/pull/87) - Added new SmartNodeSelector component and Jest testing framework
-- [#76](https://github.com/equinor/webviz-core-components/pull/76) - Python 3.9 support formally added (through CI).
+-   [#87](https://github.com/equinor/webviz-core-components/pull/87) - Added new SmartNodeSelector component and Jest testing framework
+-   [#76](https://github.com/equinor/webviz-core-components/pull/76) - Python 3.9 support formally added (through CI).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,166 +8,165 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [UNRELEASED] - YYYY-MM-DD
 
 ### Added
-
--   [#201](https://github.com/equinor/webviz-core-components/pull/201) - Implemented wrapper around `MaterialUI's` draggable dialog. Makes a new `Dialog` component available in `Dash`.
+- [#201](https://github.com/equinor/webviz-core-components/pull/201) - Implemented wrapper around `MaterialUI's` draggable dialog. Makes a new `Dialog` component available in `Dash`.
 
 ## [0.5.5] - 2022-02-09
 
 ### Changed
 
--   [#197](https://github.com/equinor/webviz-core-components/pull/197) - Updated `@equinor/eds-icons` (and associated `@equinor/eds-core-react` dependencies) in order to use new icons upstream in the application menu.
+- [#197](https://github.com/equinor/webviz-core-components/pull/197) - Updated `@equinor/eds-icons` (and associated `@equinor/eds-core-react` dependencies) in order to use new icons upstream in the application menu.
 
 ## [0.5.4] - 2021-12-09
 
 ### Fixed
 
--   [#178](https://github.com/equinor/webviz-core-components/pull/178) - Bug fixes in `SmartNodeSelector`: Placeholder not applied, text width not calculated correctly initially, jump to next node when pressing `Enter`, bug fixes and improvements when navigating with arrows. Node names containing `-` were breaking the code.
--   [#191](https://github.com/equinor/webviz-core-components/pull/191) - Removed `pointer` cursor from `webviz-selectors` class.
+- [#178](https://github.com/equinor/webviz-core-components/pull/178) - Bug fixes in `SmartNodeSelector`: Placeholder not applied, text width not calculated correctly initially, jump to next node when pressing `Enter`, bug fixes and improvements when navigating with arrows. Node names containing `-` were breaking the code.
+- [#191](https://github.com/equinor/webviz-core-components/pull/191) - Removed `pointer` cursor from `webviz-selectors` class.
 
 ### Added
 
--   [#178](https://github.com/equinor/webviz-core-components/pull/178) - Implemented case-insensitive and description search in `SmartNodeSelector`.
+- [#178](https://github.com/equinor/webviz-core-components/pull/178) - Implemented case-insensitive and description search in `SmartNodeSelector`. 
     Also added export of data types and implemented `OR` operator in nodes as beta feature. Implemented better visual feedback, tab and end/home navigation. Implemented visual feedback and possibility to show all suggestions.
 
 ## [0.5.3] - 2021-11-08
 
 ### Changed
 
--   [#181](https://github.com/equinor/webviz-core-components/pull/181) - `SmartNodeSelector` suggestions window is now attached at top level of DOM tree. This improves usability when used in a scroll area.
+- [#181](https://github.com/equinor/webviz-core-components/pull/181) - `SmartNodeSelector` suggestions window is now attached at top level of DOM tree. This improves usability when used in a scroll area.
 
 ### Fixed
 
--   [#177](https://github.com/equinor/webviz-core-components/pull/177) - Bug fix: Menu missing if using non-existent icon.
+- [#177](https://github.com/equinor/webviz-core-components/pull/177) - Bug fix: Menu missing if using non-existent icon.
 
 ### Added
 
--   [#182](https://github.com/equinor/webviz-core-components/pull/182) - Added option to wrap `SelectWithLabel` in a `Details` collapsible widget.
--   [#174](https://github.com/equinor/webviz-core-components/pull/174) - Implemented `initiallyCollapsed` setting for menu.
+- [#182](https://github.com/equinor/webviz-core-components/pull/182) - Added option to wrap `SelectWithLabel` in a `Details` collapsible widget.
+- [#174](https://github.com/equinor/webviz-core-components/pull/174) - Implemented `initiallyCollapsed` setting for menu.
 
 ## [0.5.2] - 2021-10-08
 
 ### Changed
 
--   [#161](https://github.com/equinor/webviz-core-components/pull/161) - Updated to `Dash 2.0`.
--   [#173](https://github.com/equinor/webviz-core-components/pull/173) - Improved menu layout and auto-width.
+- [#161](https://github.com/equinor/webviz-core-components/pull/161) - Updated to `Dash 2.0`.
+- [#173](https://github.com/equinor/webviz-core-components/pull/173) - Improved menu layout and auto-width.
 
 ### Fixed
 
--   [#157](https://github.com/equinor/webviz-core-components/pull/157) - Added utf8 encoding to Python's `open()` calls.
--   [#158](https://github.com/equinor/webviz-core-components/pull/158) - Fixed error messages when contact person details not provided to `WebvizPluginPlaceholder`.
--   [#159](https://github.com/equinor/webviz-core-components/pull/159) - Call `revokeObjectURL` after using `createObjectURL` in `WebvizPluginPlaceholder`.
--   [#160](https://github.com/equinor/webviz-core-components/pull/160) - Bug fix: `Select` property `value` does not return correct type.
--   [#172](https://github.com/equinor/webviz-core-components/pull/172) - Bug fix: No margin between plugins.
+- [#157](https://github.com/equinor/webviz-core-components/pull/157) - Added utf8 encoding to Python's `open()` calls.
+- [#158](https://github.com/equinor/webviz-core-components/pull/158) - Fixed error messages when contact person details not provided to `WebvizPluginPlaceholder`.
+- [#159](https://github.com/equinor/webviz-core-components/pull/159) - Call `revokeObjectURL` after using `createObjectURL` in `WebvizPluginPlaceholder`.
+- [#160](https://github.com/equinor/webviz-core-components/pull/160) - Bug fix: `Select` property `value` does not return correct type.
+- [#172](https://github.com/equinor/webviz-core-components/pull/172) - Bug fix: No margin between plugins.
 
 ### Added
 
--   [#154](https://github.com/equinor/webviz-core-components/pull/154) - Implemented new menu component.
+- [#154](https://github.com/equinor/webviz-core-components/pull/154) - Implemented new menu component.
 
 ## [0.5.1] - 2021-07-12
 
 ### Changed
 
--   [#140](https://github.com/equinor/webviz-core-components/pull/140) - Improved styling of the `Select` component.
--   [#145](https://github.com/equinor/webviz-core-components/pull/145) - Added wrapper components for typically used Dash components (Dropdown, Slider, etc) with additional styling.
--   [#148](https://github.com/equinor/webviz-core-components/pull/148) - Changed default value of `numSecondsUntilSuggestionsAreShown` to 0.5 in `SmartNodeSelector` component
--   [#150](https://github.com/equinor/webviz-core-components/pull/150) - Changed color of single remove button in `SmartNodeSelector` to the same as for the remove all button.
--   [#151](https://github.com/equinor/webviz-core-components/pull/151) - `SmartNodeSelector`: Changes to `data` and `delimiter` props are considered now and cause the component to update.
+- [#140](https://github.com/equinor/webviz-core-components/pull/140) - Improved styling of the `Select` component.
+- [#145](https://github.com/equinor/webviz-core-components/pull/145) - Added wrapper components for typically used Dash components (Dropdown, Slider, etc) with additional styling.
+- [#148](https://github.com/equinor/webviz-core-components/pull/148) - Changed default value of `numSecondsUntilSuggestionsAreShown` to 0.5 in `SmartNodeSelector` component
+- [#150](https://github.com/equinor/webviz-core-components/pull/150) - Changed color of single remove button in `SmartNodeSelector` to the same as for the remove all button.
+- [#151](https://github.com/equinor/webviz-core-components/pull/151) - `SmartNodeSelector`: Changes to `data` and `delimiter` props are considered now and cause the component to update.
 
 ### Added
 
--   [#148](https://github.com/equinor/webviz-core-components/pull/148) - Added `lineBreakAfterTag` property to `SmartNodeSelector` which defaults to false. If set to true, tags are separated by a line break.
+- [#148](https://github.com/equinor/webviz-core-components/pull/148) - Added `lineBreakAfterTag` property to `SmartNodeSelector` which defaults to false. If set to true, tags are separated by a line break.
 
 ## [0.5.0] - 2021-06-06
 
 ### Changed
 
--   [#134](https://github.com/equinor/webviz-core-components/pull/134) - When prereleases are done in GitHub, they will now be published to `npm` using the `next` tag. E.g. `npm install @webviz/core-components` will install the latest official release, while `npm install @webviz/core-components@next` will install the
+- [#134](https://github.com/equinor/webviz-core-components/pull/134) - When prereleases are done in GitHub, they will now be published to `npm` using the `next` tag. E.g. `npm install @webviz/core-components` will install the latest official release, while `npm install @webviz/core-components@next` will install the
     latest prerelease.
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Moved `React` code and `Node.js` configuration into `./react/` directory.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Moved `React` code and `Node.js` configuration into `./react/` directory.
     Adjusted `package.json`, `.gitignore`, `.vscode/launch.js` and GitHub workflow file accordingly.
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Tightened `tsconfig` options in order to have a more strict code validation.
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Synchronized ECMA Script version in `tsconfig` and `eslint`.
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added automatic removal of unused autogenerated files (`.Rbuildignore`).
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Removed `plotly-cartesian.js` and `package.json` (top level) from `MANIFEST.in`.
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Adjusted components according to new `tsconfig` options.
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Moved `flexbox.css` into new component folder.
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Introduced `DefaultPropsHelper.ts` in order to account for coexistence of TypeScript restrictions and `React`'s `defaultProps`.
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - `setup.py` is now reading package data from `package.json` file inside `webviz_core_components`.
--   [#121](https://github.com/equinor/webviz-core-components/pull/121) - Changed rendering of `SmartNodeSelector` component when only one node can be selected.
--   [#136](https://github.com/equinor/webviz-core-components/pull/136) - Changes to selected tags in `SmartNodeSelector` are now always sent.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Tightened `tsconfig` options in order to have a more strict code validation.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Synchronized ECMA Script version in `tsconfig` and `eslint`.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added automatic removal of unused autogenerated files (`.Rbuildignore`).
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Removed `plotly-cartesian.js` and `package.json` (top level) from `MANIFEST.in`.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Adjusted components according to new `tsconfig` options.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Moved `flexbox.css` into new component folder.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Introduced `DefaultPropsHelper.ts` in order to account for coexistence of TypeScript restrictions and `React`'s `defaultProps`.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - `setup.py` is now reading package data from `package.json` file inside `webviz_core_components`.
+- [#121](https://github.com/equinor/webviz-core-components/pull/121) - Changed rendering of `SmartNodeSelector` component when only one node can be selected.
+- [#136](https://github.com/equinor/webviz-core-components/pull/136) - Changes to selected tags in `SmartNodeSelector` are now always sent.
 
 ### Added
 
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added `Storybook` for demo of components.
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added `declarations.d.ts` file for ambient declarations for npm modules without type declarations.
--   [#130](https://github.com/equinor/webviz-core-components/pull/130) - Added feedback button to `WebvizPluginPlaceholder`. Added `href` and `target` properties to `WebvizToolbarButton`.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added `Storybook` for demo of components.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Added `declarations.d.ts` file for ambient declarations for npm modules without type declarations.
+- [#130](https://github.com/equinor/webviz-core-components/pull/130) - Added feedback button to `WebvizPluginPlaceholder`. Added `href` and `target` properties to `WebvizToolbarButton`.
 
 ### Fixed
 
--   [#136](https://github.com/equinor/webviz-core-components/pull/136) - Several bug fixes in `SmartNodeSelector` (exception on entering invalid node name when no metadata given, exception on using several wildcards,
+- [#136](https://github.com/equinor/webviz-core-components/pull/136) - Several bug fixes in `SmartNodeSelector` (exception on entering invalid node name when no metadata given, exception on using several wildcards,
     new tag when pressing enter with single node selection and invalid data, node selected several times when its name is partly contained in other nodes, exception on holding backspace pressed).
--   [#125](https://github.com/equinor/webviz-core-components/pull/125) - Removed `selectedNodes` attribute from `SmartNodeSelector` arguments in `usage.py`.
--   [#124](https://github.com/equinor/webviz-core-components/pull/124) - `SmartNodeSelector` now returns all selected tags (also invalid and duplicate ones) to parent.
--   [#123](https://github.com/equinor/webviz-core-components/pull/123) - Removed unused variables and added types to `SmartNodeSelector` and its tests.
+- [#125](https://github.com/equinor/webviz-core-components/pull/125) - Removed `selectedNodes` attribute from `SmartNodeSelector` arguments in `usage.py`.
+- [#124](https://github.com/equinor/webviz-core-components/pull/124) - `SmartNodeSelector` now returns all selected tags (also invalid and duplicate ones) to parent.
+- [#123](https://github.com/equinor/webviz-core-components/pull/123) - Removed unused variables and added types to `SmartNodeSelector` and its tests.
 
 ## [0.4.1] - 2021-05-04
 
 ### Fixed
 
--   [#122](https://github.com/equinor/webviz-core-components/pull/122) - Fixed bug in `WebvizPluginPlaceholder` preventing download button from working. Added tests for `WebvizPluginPlaceholder`.
--   [#120](https://github.com/equinor/webviz-core-components/pull/120) - Multiple bug fixes (deletion of currently selected tag not possible; state not dynamically updated;
+- [#122](https://github.com/equinor/webviz-core-components/pull/122) - Fixed bug in `WebvizPluginPlaceholder` preventing download button from working. Added tests for `WebvizPluginPlaceholder`.
+- [#120](https://github.com/equinor/webviz-core-components/pull/120) - Multiple bug fixes (deletion of currently selected tag not possible; state not dynamically updated;
     empty or invalid node names no longer allowed; auto resizing not working when initializing tag component) and new tests for these bugs. Also removed unnecessary properties.
 
 ## [0.4.0] - 2021-04-26
 
 ### Added
 
--   [#114](https://github.com/equinor/webviz-core-components/pull/114) - Added deprecation warning to `WebvizPluginPlaceholder`.
+- [#114](https://github.com/equinor/webviz-core-components/pull/114) - Added deprecation warning to `WebvizPluginPlaceholder`.
 
 ### Changed
 
--   [#114](https://github.com/equinor/webviz-core-components/pull/114) - Better alignment of tooltips with icons and pointer cursor when hovering buttons in `WebvizPluginPlaceholder`.
--   [#118](https://github.com/equinor/webviz-core-components/pull/118) - Remove `toImage` from default `modeBarButtonsToRemove` in `wcc.Graph`.
+- [#114](https://github.com/equinor/webviz-core-components/pull/114) - Better alignment of tooltips with icons and pointer cursor when hovering buttons in `WebvizPluginPlaceholder`.
+- [#118](https://github.com/equinor/webviz-core-components/pull/118) - Remove `toImage` from default `modeBarButtonsToRemove` in `wcc.Graph`.
 
 ### Fixed
 
--   [#114](https://github.com/equinor/webviz-core-components/pull/114) - Fixed bug in `WebvizPluginPlaceholder` preventing tooltips from being shown.
+- [#114](https://github.com/equinor/webviz-core-components/pull/114) - Fixed bug in `WebvizPluginPlaceholder` preventing tooltips from being shown.
 
 ## [0.3.2] - 2021-04-09
 
--   [#115](https://github.com/equinor/webviz-core-components/pull/115) - Removed postinstall script in order to not having npm trying to copy package.json when installing as npm package.
--   [#113](https://github.com/equinor/webviz-core-components/pull/113) - Fixed LGTM warnings caused by SmartNodeSelector component's defaultProps definitions.
--   [#107](https://github.com/equinor/webviz-core-components/pull/107) - Fixed bug in argument modifier method (when input argument is given as positional).
--   [#107](https://github.com/equinor/webviz-core-components/pull/107) - Prevent false positives through LGTM/GitHub CodeQL.
+- [#115](https://github.com/equinor/webviz-core-components/pull/115) - Removed postinstall script in order to not having npm trying to copy package.json when installing as npm package.
+- [#113](https://github.com/equinor/webviz-core-components/pull/113) - Fixed LGTM warnings caused by SmartNodeSelector component's defaultProps definitions.
+- [#107](https://github.com/equinor/webviz-core-components/pull/107) - Fixed bug in argument modifier method (when input argument is given as positional).
+- [#107](https://github.com/equinor/webviz-core-components/pull/107) - Prevent false positives through LGTM/GitHub CodeQL.
 
 ## [0.3.1] - 2021-03-28
 
 ### Fixed
 
--   [#105](https://github.com/equinor/webviz-core-components/pull/105) - Fixed bug when updating Select values from a Dash callback.
+- [#105](https://github.com/equinor/webviz-core-components/pull/105) - Fixed bug when updating Select values from a Dash callback.
 
 ## [0.3.0] - 2021-03-26
 
 ### Fixed
 
--   [#99](https://github.com/equinor/webviz-core-components/pull/99) - Fixed bug which prevented using the download button in `WebvizPluginPlaceholder` and started to download when component was mounting.
+- [#99](https://github.com/equinor/webviz-core-components/pull/99) - Fixed bug which prevented using the download button in `WebvizPluginPlaceholder` and started to download when component was mounting.
 
 ### Added
 
--   [#96](https://github.com/equinor/webviz-core-components/pull/96) - Added publishing of npm package to Github Workflow
+- [#96](https://github.com/equinor/webviz-core-components/pull/96) - Added publishing of npm package to Github Workflow
 
 ### Changed
 
--   [#100](https://github.com/equinor/webviz-core-components/pull/100) - Adjusted build environment in order to be able to write
+- [#100](https://github.com/equinor/webviz-core-components/pull/100) - Adjusted build environment in order to be able to write
     components in TypeScript and to publish to npm. Also changed all components to TypeScript.
 
 ## [0.2.0] - 2021-03-11
 
 ### Changed
 
--   [#86](https://github.com/equinor/webviz-core-components/pull/86) - Refactored and converted code to TypeScript (main component files to JSX), adjusted build environment accordingly and added validation of JS/TS to GitHub workflow
+- [#86](https://github.com/equinor/webviz-core-components/pull/86) - Refactored and converted code to TypeScript (main component files to JSX), adjusted build environment accordingly and added validation of JS/TS to GitHub workflow
 
 ### Added
 
--   [#87](https://github.com/equinor/webviz-core-components/pull/87) - Added new SmartNodeSelector component and Jest testing framework
--   [#76](https://github.com/equinor/webviz-core-components/pull/76) - Python 3.9 support formally added (through CI).
+- [#87](https://github.com/equinor/webviz-core-components/pull/87) - Added new SmartNodeSelector component and Jest testing framework
+- [#76](https://github.com/equinor/webviz-core-components/pull/76) - Python 3.9 support formally added (through CI).

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -23,6 +23,7 @@
                 "lodash": "^4.17.21",
                 "notistack": "^1.0.5",
                 "react-colorscales": "^0.7.3",
+                "react-draggable": "^4.4.4",
                 "reactour": "^1.18.3",
                 "styled-components": "^5.2.1"
             },
@@ -23685,13 +23686,16 @@
             }
         },
         "node_modules/react-draggable": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.3.tgz",
-            "integrity": "sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==",
-            "dev": true,
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.4.tgz",
+            "integrity": "sha512-6e0WdcNLwpBx/YIDpoyd2Xb04PB0elrDrulKUgdrIlwuYvxh5Ok9M+F8cljm8kPXXs43PmMzek9RrB1b7mLMqA==",
             "dependencies": {
-                "classnames": "^2.2.5",
+                "clsx": "^1.1.1",
                 "prop-types": "^15.6.0"
+            },
+            "peerDependencies": {
+                "react": ">= 16.3.0",
+                "react-dom": ">= 16.3.0"
             }
         },
         "node_modules/react-element-to-jsx-string": {
@@ -32741,6 +32745,7 @@
             "integrity": "sha512-qOtwgiqI3LMqT0eXYNV6ykp7qSu0LQGeXxy3wOBGuDDqAizfgnAjomYEWGFcyKp5ahV7HCRCjxbixAklFPUmyw==",
             "dev": true,
             "requires": {
+                "@babel/core": "^7.12.10",
                 "@babel/generator": "^7.12.11",
                 "@babel/parser": "^7.12.11",
                 "@babel/plugin-transform-react-jsx": "^7.12.12",
@@ -49326,12 +49331,11 @@
             }
         },
         "react-draggable": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.3.tgz",
-            "integrity": "sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==",
-            "dev": true,
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.4.tgz",
+            "integrity": "sha512-6e0WdcNLwpBx/YIDpoyd2Xb04PB0elrDrulKUgdrIlwuYvxh5Ok9M+F8cljm8kPXXs43PmMzek9RrB1b7mLMqA==",
             "requires": {
-                "classnames": "^2.2.5",
+                "clsx": "^1.1.1",
                 "prop-types": "^15.6.0"
             }
         },

--- a/react/package.json
+++ b/react/package.json
@@ -56,6 +56,7 @@
         "lodash": "^4.17.21",
         "notistack": "^1.0.5",
         "react-colorscales": "^0.7.3",
+        "react-draggable": "^4.4.4",
         "reactour": "^1.18.3",
         "styled-components": "^5.2.1"
     },

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,5 @@
 {
     "name": "@webviz/core-components",
-    "version": "0.5.8",
     "description": "Core components for webviz-config",
     "repository": {
         "type": "git",

--- a/react/src/demo/App.tsx
+++ b/react/src/demo/App.tsx
@@ -6,9 +6,15 @@
  */
 
 /* eslint no-magic-numbers: 0 */
+import { Button } from "@material-ui/core";
 import React from "react";
 
-import { WebvizPluginPlaceholder, SmartNodeSelector, Menu } from "../lib";
+import {
+    WebvizPluginPlaceholder,
+    SmartNodeSelector,
+    Menu,
+    Dialog,
+} from "../lib";
 
 const steps = [
     {
@@ -45,6 +51,8 @@ const App: React.FC = () => {
         url: "",
     });
 
+    const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
+
     return (
         <div>
             <Menu
@@ -71,6 +79,11 @@ const App: React.FC = () => {
                                         title: "SmartNodeSelector",
                                         href: "#smart-node-selector",
                                     },
+                                    {
+                                        type: "page",
+                                        title: "Dialog",
+                                        href: "#dialog",
+                                    },
                                 ],
                             },
                         ],
@@ -83,6 +96,33 @@ const App: React.FC = () => {
                     <h1>webviz-core-components - Demo page</h1>Please select a
                     component from the menu to view its demo application.
                 </div>
+            )}
+            {currentPage.url.split("#")[1] === "dialog" && (
+                <>
+                    <h1>Dialog</h1>
+                    <Button
+                        component="button"
+                        onClick={() => setDialogOpen(true)}
+                    >
+                        Open Dialog
+                    </Button>
+                    <Dialog
+                        title="Dialog title"
+                        id="dialog"
+                        max_width="xl"
+                        open={dialogOpen}
+                        draggable={true}
+                        setProps={(newProps) => {
+                            console.log(newProps);
+                            setDialogOpen(newProps.open);
+                        }}
+                        actions={["Cancel", "OK"]}
+                    >
+                        <div style={{ width: 2000 }}>
+                            This is the content of the dialog.
+                        </div>
+                    </Dialog>
+                </>
             )}
             {currentPage.url.split("#")[1] === "webviz-plugin-placeholder" && (
                 <>
@@ -122,7 +162,7 @@ const App: React.FC = () => {
                         delimiter=":"
                         placeholder="This is a very long placeholder..."
                         selectedTags={nodeSelectorState.selectedTags}
-                        caseInsensitiveMatching={true}
+                        caseInsensitiveMatching={false}
                         setProps={setNodeSelectorState}
                         label="Smart Tree Node Selector"
                         data={[

--- a/react/src/lib/components/Dialog/Dialog.tsx
+++ b/react/src/lib/components/Dialog/Dialog.tsx
@@ -1,0 +1,186 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import {
+    Button,
+    Dialog as MuiDialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+    Typography,
+} from "@material-ui/core";
+import Paper from "@material-ui/core/Paper";
+
+import { Icon } from "@equinor/eds-core-react";
+import { close } from "@equinor/eds-icons";
+
+Icon.add({ close });
+
+import { DraggablePaperComponent } from "./components/DraggablePaperComponent";
+
+type DialogProps = {
+    id: string;
+    open?: boolean;
+    draggable?: boolean;
+    title: string;
+    children?: React.ReactNode;
+    onClose?: (reason: string) => void;
+    onCancel?: () => void;
+    onSave?: () => void;
+    onOk?: () => void;
+    onAgree?: () => void;
+    onDisagree?: () => void;
+};
+
+/**
+ * A modal dialog component with optional buttons. Can be set to be draggable.
+ */
+export const Dialog: React.FC<DialogProps> = (props) => {
+    const [open, setOpen] = React.useState<boolean>(props.open || false);
+
+    React.useEffect(() => {
+        setOpen(props.open || false);
+    }, [props.open]);
+
+    const handleClose = (reason: string) => {
+        setOpen(false);
+        if (props.onClose) {
+            props.onClose(reason);
+        }
+    };
+
+    return (
+        <MuiDialog
+            id={props.id}
+            open={open}
+            onClose={(_: React.MouseEvent<HTMLAnchorElement>, reason: string) =>
+                handleClose(reason)
+            }
+            PaperComponent={props.draggable ? DraggablePaperComponent : Paper}
+            aria-labelledby="dialog-title"
+        >
+            <DialogTitle
+                style={{ cursor: props.draggable ? "move" : "default" }}
+                id="draggable-dialog-title"
+            >
+                <Typography variant="h6">{props.title}</Typography>
+                <IconButton
+                    aria-label="close"
+                    onClick={() => handleClose("dialog-button-click")}
+                    style={{
+                        position: "absolute",
+                        right: 8,
+                        top: 8,
+                        color: "#ccc",
+                    }}
+                >
+                    <Icon name="close" />
+                </IconButton>
+            </DialogTitle>
+            <DialogContent>{props.children}</DialogContent>
+            <DialogActions>
+                {props.onClose && (
+                    <Button
+                        component="button"
+                        onClick={() =>
+                            props.onClose && props.onClose("button-click")
+                        }
+                    >
+                        Close
+                    </Button>
+                )}
+                {props.onCancel && (
+                    <Button
+                        component="button"
+                        onClick={() => props.onCancel && props.onCancel()}
+                    >
+                        Cancel
+                    </Button>
+                )}
+                {props.onDisagree && (
+                    <Button
+                        component="button"
+                        onClick={() => props.onDisagree && props.onDisagree()}
+                    >
+                        Disagree
+                    </Button>
+                )}
+                {props.onAgree && (
+                    <Button
+                        component="button"
+                        onClick={() => props.onAgree && props.onAgree()}
+                    >
+                        Agree
+                    </Button>
+                )}
+                {props.onOk && (
+                    <Button
+                        component="button"
+                        onClick={() => props.onOk && props.onOk()}
+                    >
+                        OK
+                    </Button>
+                )}
+                {props.onSave && (
+                    <Button
+                        component="button"
+                        onClick={() => props.onSave && props.onSave()}
+                    >
+                        Save
+                    </Button>
+                )}
+            </DialogActions>
+        </MuiDialog>
+    );
+};
+
+Dialog.propTypes = {
+    /**
+     * The ID used to identify this component in Dash callbacks.
+     */
+    id: PropTypes.string.isRequired,
+    /**
+     * States if the dialog is open or not.
+     */
+    open: PropTypes.bool,
+    /**
+     * Set to true if the dialog shall be draggable.
+     */
+    draggable: PropTypes.bool,
+    /**
+     * The title of the dialog.
+     */
+    title: PropTypes.string.isRequired,
+    /**
+     * The child elements showed in the dialog
+     */
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]),
+    /**
+     * If defined, a "close" button is shown. Called when the dialog is closed.
+     */
+    onClose: PropTypes.func,
+    /**
+     * If defined, a "cancel" button is shown. Called when the cancel button is pressed.
+     */
+    onCancel: PropTypes.func,
+    /**
+     * If defined, a "disagree" button is shown. Called when the disagree button is pressed.
+     */
+    onDisagree: PropTypes.func,
+    /**
+     * If defined, a "save" button is shown. Called when the save button is pressed.
+     */
+    onSave: PropTypes.func,
+    /**
+     * If defined, an "ok" button is shown. Called when the ok button is pressed.
+     */
+    onOk: PropTypes.func,
+    /**
+     * If defined, an "agree" button is shown. Called when the agree button is pressed.
+     */
+    onAgree: PropTypes.func,
+};

--- a/react/src/lib/components/Dialog/Dialog.tsx
+++ b/react/src/lib/components/Dialog/Dialog.tsx
@@ -32,6 +32,14 @@ const propTypes = {
      */
     open: PropTypes.bool,
     /**
+     * Width of the dialog. Can be one of 'xs' | 'sm' | 'md' | 'lg' | 'xl'.
+     */
+    max_width: PropTypes.oneOf(["xs", "sm", "md", "lg", "xl"]),
+    /**
+     * Set to true to show the dialog fullscreen.
+     */
+    full_screen: PropTypes.bool,
+    /**
      * Set to true if the dialog shall be draggable.
      */
     draggable: PropTypes.bool,
@@ -67,7 +75,9 @@ const propTypes = {
 
 const defaultProps: Optionals<InferProps<typeof propTypes>> = {
     open: false,
+    max_width: null,
     draggable: false,
+    full_screen: false,
     children: null,
     actions: [],
     last_action_called: null,
@@ -119,6 +129,17 @@ export const Dialog: React.FC<InferProps<typeof propTypes>> = (props) => {
                 adjustedProps.draggable ? DraggablePaperComponent : Paper
             }
             aria-labelledby="dialog-title"
+            maxWidth={
+                (adjustedProps.max_width as
+                    | "xs"
+                    | "sm"
+                    | "md"
+                    | "lg"
+                    | "xl"
+                    | null) || false
+            }
+            fullScreen={adjustedProps.full_screen}
+            scroll="body"
         >
             <DialogTitle
                 style={{

--- a/react/src/lib/components/Dialog/Dialog.tsx
+++ b/react/src/lib/components/Dialog/Dialog.tsx
@@ -8,7 +8,6 @@ import {
     DialogContent,
     DialogTitle,
     IconButton,
-    Typography,
 } from "@material-ui/core";
 import Paper from "@material-ui/core/Paper";
 
@@ -52,9 +51,13 @@ const propTypes = {
      */
     actions: PropTypes.arrayOf(PropTypes.string),
     /**
-     *
+     * The name of the action that was called last.
      */
-    action_called: PropTypes.string,
+    last_action_called: PropTypes.string,
+    /**
+     * A counter for how often actions have been called so far.
+     */
+    actions_called: PropTypes.number,
     /**
      * Dash-assigned callback that should be called whenever any of the
      * properties change.
@@ -67,7 +70,8 @@ const defaultProps: Optionals<InferProps<typeof propTypes>> = {
     draggable: false,
     children: null,
     actions: [],
-    action_called: null,
+    last_action_called: null,
+    actions_called: 0,
     setProps: () => {
         return;
     },
@@ -86,14 +90,11 @@ export const Dialog: React.FC<InferProps<typeof propTypes>> = (props) => {
         adjustedProps.open || false
     );
 
-    React.useEffect(() => {
-        setOpen(adjustedProps.open || false);
-        adjustedProps.setProps({ action_called: null });
-    }, [adjustedProps.open]);
+    const [actionsCalled, setActionsCalled] = React.useState<number>(0);
 
     React.useEffect(() => {
-        adjustedProps.setProps({ action_called: null });
-    }, [adjustedProps.action_called]);
+        setOpen(adjustedProps.open || false);
+    }, [adjustedProps.open]);
 
     const handleClose = () => {
         setOpen(false);
@@ -101,7 +102,12 @@ export const Dialog: React.FC<InferProps<typeof propTypes>> = (props) => {
     };
 
     const handleButtonClick = (action: string) => {
-        adjustedProps.setProps({ action_called: action });
+        adjustedProps.setProps({
+            action_called: action,
+            open: open,
+            actions_called: actionsCalled + 1,
+        });
+        setActionsCalled(actionsCalled + 1);
     };
 
     return (
@@ -115,10 +121,13 @@ export const Dialog: React.FC<InferProps<typeof propTypes>> = (props) => {
             aria-labelledby="dialog-title"
         >
             <DialogTitle
-                style={{ cursor: adjustedProps.draggable ? "move" : "default" }}
+                style={{
+                    cursor: adjustedProps.draggable ? "move" : "default",
+                    marginRight: 32,
+                }}
                 id="draggable-dialog-title"
             >
-                <Typography variant="h6">{adjustedProps.title}</Typography>
+                {adjustedProps.title}
                 <IconButton
                     aria-label="close"
                     onClick={() => handleClose()}

--- a/react/src/lib/components/Dialog/components/DraggablePaperComponent.tsx
+++ b/react/src/lib/components/Dialog/components/DraggablePaperComponent.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+import Paper, { PaperProps } from "@material-ui/core/Paper";
+import Draggable from "react-draggable";
+
+export const DraggablePaperComponent: React.FC<PaperProps> = (props) => {
+    return (
+        <Draggable
+            handle="#draggable-dialog-title"
+            cancel={'[class*="MuiDialogContent-root"]'}
+        >
+            <Paper {...props} />
+        </Draggable>
+    );
+};

--- a/react/src/lib/index.ts
+++ b/react/src/lib/index.ts
@@ -19,6 +19,7 @@ import SmartNodeSelector, {
 import { Menu } from "./components/Menu";
 import { Overlay } from "./components/Overlay";
 import { ScrollArea } from "./components/ScrollArea";
+import { Dialog } from "./components/Dialog/Dialog";
 
 import "./components/FlexBox/flexbox.css";
 import "./components/Layout";
@@ -37,4 +38,5 @@ export {
     Menu,
     Overlay,
     ScrollArea,
+    Dialog,
 };


### PR DESCRIPTION
Added a wrapper around https://mui.com/components/dialogs/. This partially addresses https://github.com/equinor/webviz-config/issues/578.