### PR TITLE
Adjusted z-index for suggestions of `SmartNodeSelector` to hard-coded value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Added
+- [#202](https://github.com/equinor/webviz-core-components/pull/202) - Adjusted `z-index` of suggestions of `SmartNodeSelector` to a hard-coded value of `1500`.
+
 ## [0.5.5] - 2022-02-09
 
 ### Changed

--- a/react/src/lib/components/SmartNodeSelector/components/Suggestions.css
+++ b/react/src/lib/components/SmartNodeSelector/components/Suggestions.css
@@ -17,6 +17,7 @@
     overflow-y: auto;
     -webkit-box-shadow: 0px 4px 5px -1px rgba(0, 0, 0, 0.2);
     box-shadow: 0px 4px 5px -1px rgba(0, 0, 0, 0.2);
+    z-index: 1500;
 }
 
 .Suggestions__Position {

--- a/react/src/lib/components/SmartNodeSelector/components/Suggestions.tsx
+++ b/react/src/lib/components/SmartNodeSelector/components/Suggestions.tsx
@@ -12,7 +12,6 @@ import PropTypes from "prop-types";
 
 import TreeNodeSelection from "../utils/TreeNodeSelection";
 import { TreeDataNodeMetaData } from "../utils/TreeDataNodeTypes";
-import { findHighestZIndex } from "../../../utils/dom";
 
 import "./Suggestions.css";
 
@@ -514,10 +513,6 @@ class Suggestions extends Component<SuggestionsProps> {
                   height: 0,
               };
 
-        const zIndex = this.positionRef.current
-            ? findHighestZIndex(this.positionRef.current) + 1
-            : 99;
-
         ReactDOM.render(
             <div
                 ref={suggestionsRef}
@@ -529,7 +524,6 @@ class Suggestions extends Component<SuggestionsProps> {
                     top: boundingRect.top,
                     left: boundingRect.left,
                     width: boundingRect.width,
-                    zIndex: zIndex,
                 }}
             >
                 <div


### PR DESCRIPTION
Adjusted `z-index` of suggestions to a hard-coded value of `1500`. Compared to before, this will most likely always display the suggestions container on top of all other elements and is more performant than the aforeused `z-index` search algorithm.