### PR TITLE
Bug fix: settings drawer not collapsing (not collapsable) if no settings group given

### DIFF
--- a/react/src/lib/components/WebvizSettingsDrawer/WebvizSettingsDrawer.tsx
+++ b/react/src/lib/components/WebvizSettingsDrawer/WebvizSettingsDrawer.tsx
@@ -129,9 +129,11 @@ export const WebvizSettingsDrawer: React.FC<WebvizSettingsDrawerProps> = (
                 store.state.position.slice(1)
             }`}
             style={{
-                width: store.state.settingsDrawerOpen
-                    ? expandedWidth
-                    : collapsedWidth,
+                width:
+                    store.state.settingsDrawerOpen &&
+                    React.Children.count(props.children) > 0
+                        ? expandedWidth
+                        : collapsedWidth,
                 left: position.left,
                 top: position.top,
                 right: position.right,


### PR DESCRIPTION
This fixes https://github.com/equinor/webviz-config/issues/609.