### PR TITLE
Adjusted bug in tour component displaying messages outside view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   [#220](https://github.com/equinor/webviz-core-components/pull/220) - `Overlay` was hiding menu due to conflicting z-index properties. Added `zIndex` prop to `Overlay` component and adjusted consumers.
 -   [#233](https://github.com/equinor/webviz-core-components/pull/233) - Settings drawer not collapsing (not collapsable) if no settings group given.
+-   [#234](https://github.com/equinor/webviz-core-components/pull/234) - Adjusted message window width in Webviz tour component according to remaining view width.
 
 ### Added
 

--- a/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
+++ b/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
@@ -214,6 +214,22 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
                             top: contentPosition.top,
                             right: contentPosition.right,
                             bottom: contentPosition.bottom,
+                            width:
+                                contentPosition.left !== "auto"
+                                    ? Math.min(
+                                          windowSize[0] -
+                                              contentPosition.left -
+                                              32,
+                                          300
+                                      )
+                                    : contentPosition.right !== "auto"
+                                    ? Math.min(
+                                          windowSize[0] -
+                                              contentPosition.right -
+                                              32,
+                                          300
+                                      )
+                                    : 300,
                         }}
                     >
                         {pluginData && (

--- a/react/src/lib/components/WebvizPluginTour/webviz-plugin-tour.css
+++ b/react/src/lib/components/WebvizPluginTour/webviz-plugin-tour.css
@@ -42,5 +42,4 @@
     border-radius: 4px;
     z-index: 2;
     pointer-events: all;
-    min-width: 300px;
 }


### PR DESCRIPTION
Messages in the WebvizTour plugin could be displayed outside the view port. This PR fixes this issue.