### PR TITLE
Removed usage of `withStyles` in `Dialog` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   [#220](https://github.com/equinor/webviz-core-components/pull/220) - `Overlay` was hiding menu due to conflicting z-index properties. Added `zIndex` prop to `Overlay` component and adjusted consumers.
 -   [#233](https://github.com/equinor/webviz-core-components/pull/233) - Settings drawer not collapsing (not collapsable) if no settings group given.
 -   [#234](https://github.com/equinor/webviz-core-components/pull/234) - Adjusted message window width in Webviz tour component according to remaining view width.
+-   [#236](https://github.com/equinor/webviz-core-components/pull/236) - Removed usage of `withStyles` in `DialogComponent` in order to avoid class name conflicts with `webviz-subsurface-components` caused by `MaterialUI`/`jss`.
 
 ### Added
 

--- a/react/src/lib/components/Dialog/components/DialogComponent.tsx
+++ b/react/src/lib/components/Dialog/components/DialogComponent.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import {
-    withStyles,
     Button,
     Dialog as MuiDialog,
     DialogActions,
@@ -18,12 +17,6 @@ import { close } from "@equinor/eds-icons";
 Icon.add({ close });
 
 import { DraggablePaperComponent } from "./DraggablePaperComponent";
-
-const StyledMuiDialog = withStyles({
-    root: {
-        pointerEvents: "none",
-    },
-})(MuiDialog);
 
 export type DialogParentProps = {
     /**
@@ -114,7 +107,7 @@ export const DialogComponent: React.FC<DialogProps> = (props) => {
     };
 
     const content = (
-        <>
+        <div style={{ pointerEvents: "all" }}>
             <DialogTitle
                 style={{
                     cursor: props.draggable ? "move" : "default",
@@ -149,61 +142,28 @@ export const DialogComponent: React.FC<DialogProps> = (props) => {
                         </Button>
                     ))}
             </DialogActions>
-        </>
+        </div>
     );
 
-    if (props.backdrop) {
-        return (
-            <MuiDialog
-                id={props.id}
-                open={open}
-                onClose={(_, reason) => handleClose(reason)}
-                PaperComponent={
-                    props.draggable ? DraggablePaperComponent : Paper
-                }
-                aria-labelledby="dialog-title"
-                maxWidth={
-                    (props.max_width as
-                        | "xs"
-                        | "sm"
-                        | "md"
-                        | "lg"
-                        | "xl"
-                        | null) || false
-                }
-                fullScreen={props.full_screen}
-                scroll="body"
-            >
-                {content}
-            </MuiDialog>
-        );
-    } else {
-        return (
-            <StyledMuiDialog
-                id={props.id}
-                open={open}
-                onClose={(_, reason) => handleClose(reason)}
-                hideBackdrop={true}
-                PaperComponent={
-                    props.draggable ? DraggablePaperComponent : Paper
-                }
-                aria-labelledby="dialog-title"
-                maxWidth={
-                    (props.max_width as
-                        | "xs"
-                        | "sm"
-                        | "md"
-                        | "lg"
-                        | "xl"
-                        | null) || false
-                }
-                fullScreen={props.full_screen}
-                scroll="paper"
-            >
-                {content}
-            </StyledMuiDialog>
-        );
-    }
+    return (
+        <MuiDialog
+            id={props.id}
+            open={open}
+            onClose={(_, reason) => handleClose(reason)}
+            hideBackdrop={!props.backdrop}
+            PaperComponent={props.draggable ? DraggablePaperComponent : Paper}
+            aria-labelledby="draggable-dialog-title"
+            maxWidth={
+                (props.max_width as "xs" | "sm" | "md" | "lg" | "xl" | null) ||
+                false
+            }
+            fullScreen={props.full_screen}
+            scroll="body"
+            style={{ pointerEvents: "none" }}
+        >
+            {content}
+        </MuiDialog>
+    );
 };
 
 DialogComponent.propTypes = {

--- a/react/src/lib/components/Dialog/components/DraggablePaperComponent.tsx
+++ b/react/src/lib/components/Dialog/components/DraggablePaperComponent.tsx
@@ -5,7 +5,7 @@ import Draggable from "react-draggable";
 
 export const DraggablePaperComponent: React.FC<PaperProps> = (props) => {
     return (
-        <div style={{ pointerEvents: "all" }}>
+        <div>
             <Draggable
                 handle="#draggable-dialog-title"
                 cancel={'[class*="MuiDialogContent-root"]'}


### PR DESCRIPTION
Removed usage of `withStyles` in `Dialog` component in order to avoid conflicts with `webviz-subsurface-components`.

Both packages use `MaterialUI v4` which again uses `jss` under the hood with its `makeStyles` / `withStyles` functions. `jss` automatically adds `style` nodes to the DOM containing CSS with auto-generated class names (e.g. `jss1`, `jss2` etc.). However, since both packages did make use of the `makeStyles` function and both `jss` instances did not know of one another (and `jss` does not check for duplicates in the DOM when generating class names), class naming conflicts occured (e.g. the first dynamically created class in `wcc` would have the same name as the first in `wsc` - `jss1`). This lead to the `jss1` class in `wcc` being applied to all elements in `wsc` with the same class name (and vice versa) and, hence, preventing `pointer-events` (since the only class added with `jss` in `wcc` was one preventing the background of the dialog accepting pointer-events in order to make the plugin behind the dialog remain clickable/usable when no backdrop was set).

This issue is temporarily fixed by removing the usage of `withStyles` in the `Dialog` component. However, the problem itself remains and might lead to further bugs that are difficult to debug. A general solution to this issue might be to upgrade to `MaterialUI v5` which no longer uses `jss` but `emotion`. However, it is unknown if `emotion` has an implementation for checking for duplicates and works better than `jss`.