### PR TITLE
`WLF` and `Menu`: Storing of states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   [#207](https://github.com/equinor/webviz-core-components/pull/207) - Added `storybook` and stories for each component. Added publishment of `storybook` to GitHub workflow. Added `storybook` link to README.
 -   [#219](https://github.com/equinor/webviz-core-components/pull/219) - Implemented components required by the new Webviz Layout Framework (WLF)
 -   [#227](https://github.com/equinor/webviz-core-components/pull/227) - Added `EdsIcon` component in order to use icons from the Equinor Design System (EDS) directly in Python.
+-   [#240](https://github.com/equinor/webviz-core-components/pull/240) - States of menu, active view, settings drawer and settings groups are getting stored now. If no URL path is given, the one of the first page is opened now.
 
 ### Changed
 
 -   [#219](https://github.com/equinor/webviz-core-components/pull/219) - Pinned `dash` version to `2.4.x`, added more info output to GitHub workflow, switched to React version `16.14.0` in order to comply with non-maintained `react-colorscales` requirements, implemented adjustments to `Overlay` and `ScrollArea`
+-   [#240](https://github.com/equinor/webviz-core-components/pull/240) - Settings groups remain open when others are toggled (independent toggle state).
 
 ## [0.5.7] - 2022-05-05
 

--- a/react/src/lib/components/Menu/components/Group/Group.tsx
+++ b/react/src/lib/components/Menu/components/Group/Group.tsx
@@ -22,9 +22,9 @@ type GroupProps = {
 
 export const Group: React.FC<GroupProps> = (props) => {
     const [collapsed, setCollapsed] = React.useState<boolean>(
-        localStorage.getItem(`${props.id}-${props.title}`) === "true" ||
-            props.initiallyCollapsed ||
-            false
+        localStorage.getItem(`${props.id}-${props.title}`)
+            ? localStorage.getItem(`${props.id}-${props.title}`) === "true"
+            : props.initiallyCollapsed || false
     );
 
     React.useEffect(() => {

--- a/react/src/lib/components/Menu/utils/check-url.ts
+++ b/react/src/lib/components/Menu/utils/check-url.ts
@@ -1,6 +1,6 @@
 export const checkIfUrlIsCurrent = (url: string): boolean => {
     if (url.charAt(0) === "/") {
-        url = url.substr(1);
+        url = url.substring(1);
     }
     const base = window.location.href;
     const stack = base.split("/"),

--- a/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
+++ b/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
@@ -176,24 +176,30 @@ const makeStoreId = (): string => {
     return `wlf-store-${pathname}`;
 };
 
-const readStoredState = (): StoredState => {
-    const stored = JSON.parse(localStorage.getItem(makeStoreId()) || "{}");
-    return {
-        activePluginId: Object.keys(stored).includes("activePluginId")
-            ? stored.activePluginId
-            : "",
-        openSettingsGroupIds: Object.keys(stored).includes(
-            "openSettingsGroupIds"
-        )
-            ? stored.openSettingsGroupIds
-            : [],
-        settingsDrawerOpen: Object.keys(stored).includes("settingsDrawerOpen")
-            ? stored.settingsDrawerOpen
-            : false,
-        activeViewId: Object.keys(stored).includes("activeViewId")
-            ? stored.activeViewId
-            : "",
-    };
+const readStoredState = (): StoredState | null => {
+    const storedString = localStorage.getItem(makeStoreId());
+    if (storedString) {
+        const stored = JSON.parse(storedString || "{}");
+        return {
+            activePluginId: Object.keys(stored).includes("activePluginId")
+                ? stored.activePluginId
+                : "",
+            openSettingsGroupIds: Object.keys(stored).includes(
+                "openSettingsGroupIds"
+            )
+                ? stored.openSettingsGroupIds
+                : [],
+            settingsDrawerOpen: Object.keys(stored).includes(
+                "settingsDrawerOpen"
+            )
+                ? stored.settingsDrawerOpen
+                : false,
+            activeViewId: Object.keys(stored).includes("activeViewId")
+                ? stored.activeViewId
+                : "",
+        };
+    }
+    return null;
 };
 
 const storeState = (
@@ -403,7 +409,7 @@ export const WebvizContentManager: React.FC<WebvizContentManagerProps> = (
 
         const urlPathname = window.location.pathname;
         const data = readStoredState();
-        if (urlPathname !== lastUrlPathname) {
+        if (urlPathname !== lastUrlPathname && data) {
             dispatch({
                 type: StoreActions.ApplyStoredState,
                 payload: {

--- a/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
+++ b/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
@@ -191,7 +191,7 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
                     },
                 });
                 store.dispatch({
-                    type: StoreActions.SetOpenSettingsGroupId,
+                    type: StoreActions.AddOpenSettingsGroupId,
                     payload: {
                         settingsGroupId:
                             tourSteps[newTourStep].settingsGroupId || "",

--- a/react/src/lib/components/WebvizSettings/WebvizSettings.tsx
+++ b/react/src/lib/components/WebvizSettings/WebvizSettings.tsx
@@ -51,7 +51,11 @@ export const WebvizSettings: React.FC<WebvizSettingsProps> = (
     return (
         <div
             className="WebvizSettings"
-            style={{ opacity: props.visible ? 1 : 0, width: props.width }}
+            style={{
+                opacity: props.visible ? 1 : 0,
+                width: props.width,
+                pointerEvents: props.visible ? "all" : "none",
+            }}
         >
             <ScrollArea>
                 {props.children &&

--- a/react/src/lib/components/WebvizSettings/WebvizSettings.tsx
+++ b/react/src/lib/components/WebvizSettings/WebvizSettings.tsx
@@ -25,20 +25,6 @@ export const WebvizSettings: React.FC<WebvizSettingsProps> = (
         if (store.state.openSettingsGroupIds.length !== 0) {
             return;
         }
-        React.Children.forEach(props.children, (child, index) => {
-            if (React.isValidElement(child)) {
-                if (index === 0) {
-                    store.dispatch({
-                        type: StoreActions.AddOpenSettingsGroupId,
-                        payload: {
-                            settingsGroupId:
-                                child.props._dashprivate_layout.props.id,
-                        },
-                    });
-                    return;
-                }
-            }
-        });
     }, [props.children]);
 
     const handleGroupToggle = React.useCallback(

--- a/react/src/lib/components/WebvizSettings/WebvizSettings.tsx
+++ b/react/src/lib/components/WebvizSettings/WebvizSettings.tsx
@@ -19,41 +19,47 @@ export type WebvizSettingsProps = {
 export const WebvizSettings: React.FC<WebvizSettingsProps> = (
     props: WebvizSettingsProps
 ) => {
-    const [activeGroupId, setActiveGroupId] = React.useState<string>("");
     const store = useStore();
 
     React.useEffect(() => {
-        if (store.state.openSettingsGroupId !== activeGroupId) {
-            setActiveGroupId(store.state.openSettingsGroupId);
-        }
-    }, [store.state.openSettingsGroupId]);
-
-    React.useEffect(() => {
-        if (activeGroupId !== "") {
+        if (store.state.openSettingsGroupIds.length !== 0) {
             return;
         }
         React.Children.forEach(props.children, (child, index) => {
             if (React.isValidElement(child)) {
                 if (index === 0) {
-                    setActiveGroupId(child.props._dashprivate_layout.props.id);
+                    store.dispatch({
+                        type: StoreActions.AddOpenSettingsGroupId,
+                        payload: {
+                            settingsGroupId:
+                                child.props._dashprivate_layout.props.id,
+                        },
+                    });
                     return;
                 }
             }
         });
-    }, [props.children, activeGroupId]);
+    }, [props.children]);
 
     const handleGroupToggle = React.useCallback(
         (id: string) => {
-            const groupId = id === activeGroupId ? "-" : id;
-            store.dispatch({
-                type: StoreActions.SetOpenSettingsGroupId,
-                payload: {
-                    settingsGroupId: groupId,
-                },
-            });
-            setActiveGroupId(groupId);
+            if (store.state.openSettingsGroupIds.includes(id)) {
+                store.dispatch({
+                    type: StoreActions.RemoveOpenSettingsGroupId,
+                    payload: {
+                        settingsGroupId: id,
+                    },
+                });
+            } else {
+                store.dispatch({
+                    type: StoreActions.AddOpenSettingsGroupId,
+                    payload: {
+                        settingsGroupId: id,
+                    },
+                });
+            }
         },
-        [activeGroupId]
+        [store.state]
     );
 
     return (
@@ -71,10 +77,10 @@ export const WebvizSettings: React.FC<WebvizSettingsProps> = (
                                     props: {
                                         ...child.props._dashprivate_layout
                                             .props,
-                                        open:
-                                            activeGroupId ===
+                                        open: store.state.openSettingsGroupIds.includes(
                                             child.props._dashprivate_layout
-                                                .props.id,
+                                                .props.id
+                                        ),
                                         onToggle: handleGroupToggle,
                                     },
                                 },

--- a/react/src/lib/components/WebvizSettingsDrawer/components/PluginActions/plugin-actions.tsx
+++ b/react/src/lib/components/WebvizSettingsDrawer/components/PluginActions/plugin-actions.tsx
@@ -99,34 +99,39 @@ export const PluginActions: React.FC<PluginActionsProps> = (
             openCloseAnimation.current.reset();
         }
 
-        openCloseAnimation.current =
-            new Animation<OpenCloseAnimationParameters>(
-                900,
-                20,
-                [
-                    {
-                        t: 0,
-                        state: { marginBottom: 0 },
-                    },
-                    {
-                        t: 2 / 3,
-                        state: { marginBottom: -closedHeight },
-                    },
-                    {
-                        t: 1,
-                        state: { marginBottom: 0 },
-                    },
-                ],
-                Animation.Bezier,
-                (values, t) => {
-                    if (t === 2 / 3) {
-                        setOpen(!open);
+        if (!store.state.externalTrigger) {
+            openCloseAnimation.current =
+                new Animation<OpenCloseAnimationParameters>(
+                    900,
+                    20,
+                    [
+                        {
+                            t: 0,
+                            state: { marginBottom: 0 },
+                        },
+                        {
+                            t: 2 / 3,
+                            state: { marginBottom: -closedHeight },
+                        },
+                        {
+                            t: 1,
+                            state: { marginBottom: 0 },
+                        },
+                    ],
+                    Animation.Bezier,
+                    (values, t) => {
+                        if (t === 2 / 3) {
+                            setOpen(!open);
+                        }
+                        setMarginBottom(values.marginBottom);
                     }
-                    setMarginBottom(values.marginBottom);
-                }
-            );
+                );
 
-        openCloseAnimation.current.start();
+            openCloseAnimation.current.start();
+        } else {
+            setOpen(!open);
+            setMarginBottom(0);
+        }
     }, [props.open]);
 
     const handleScreenShotClick = React.useCallback(() => {

--- a/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
+++ b/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
@@ -37,6 +37,9 @@ export const WebvizSettingsGroup: React.FC<WebvizSettingsGroupProps> = (
     const completelyVisibleTimeoutRef =
         React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
+    const initialCallTimeout =
+        React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
     const [initialCall, setInitialCall] = React.useState<boolean>(true);
 
     const activePlugin = store.state.pluginsData.find(
@@ -44,7 +47,13 @@ export const WebvizSettingsGroup: React.FC<WebvizSettingsGroupProps> = (
     );
 
     React.useEffect(() => {
-        setInitialCall(false);
+        if (initialCallTimeout.current) {
+            clearTimeout(initialCallTimeout.current);
+        }
+        initialCallTimeout.current = setTimeout(
+            () => setInitialCall(false),
+            1000
+        );
     }, [props.open]);
 
     let visible = true;
@@ -80,6 +89,9 @@ export const WebvizSettingsGroup: React.FC<WebvizSettingsGroupProps> = (
         return () => {
             if (completelyVisibleTimeoutRef.current) {
                 clearTimeout(completelyVisibleTimeoutRef.current);
+            }
+            if (initialCallTimeout.current) {
+                clearTimeout(initialCallTimeout.current);
             }
         };
     }, []);

--- a/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
+++ b/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
@@ -110,7 +110,7 @@ export const WebvizSettingsGroup: React.FC<WebvizSettingsGroupProps> = (
                 <Tooltip
                     title={`${props.open ? "Close" : "Open"} settings group '${
                         props.title
-                    }`}
+                    }'`}
                 >
                     {children}
                 </Tooltip>

--- a/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
+++ b/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
@@ -37,9 +37,15 @@ export const WebvizSettingsGroup: React.FC<WebvizSettingsGroupProps> = (
     const completelyVisibleTimeoutRef =
         React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
+    const [initialCall, setInitialCall] = React.useState<boolean>(true);
+
     const activePlugin = store.state.pluginsData.find(
         (plugin) => plugin.id === store.state.activePluginId
     );
+
+    React.useEffect(() => {
+        setInitialCall(false);
+    }, [props.open]);
 
     let visible = true;
 
@@ -158,7 +164,11 @@ export const WebvizSettingsGroup: React.FC<WebvizSettingsGroupProps> = (
                 className={
                     props.alwaysOpen
                         ? "WebvizSettingsGroup__FlatContent"
-                        : "WebvizSettingsGroup__Content"
+                        : `WebvizSettingsGroup__Content${
+                              initialCall
+                                  ? " WebvizSettingsGroup__Content__Transition"
+                                  : ""
+                          }`
                 }
                 style={{
                     height: props.open || props.alwaysOpen ? contentSize[1] : 0,

--- a/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
+++ b/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
@@ -165,7 +165,7 @@ export const WebvizSettingsGroup: React.FC<WebvizSettingsGroupProps> = (
                     props.alwaysOpen
                         ? "WebvizSettingsGroup__FlatContent"
                         : `WebvizSettingsGroup__Content${
-                              initialCall
+                              !initialCall
                                   ? " WebvizSettingsGroup__Content__Transition"
                                   : ""
                           }`

--- a/react/src/lib/components/WebvizSettingsGroup/webviz-settings-group.css
+++ b/react/src/lib/components/WebvizSettingsGroup/webviz-settings-group.css
@@ -37,6 +37,9 @@
     box-shadow: 0px 3px 5px 0px rgba(0, 0, 0, 0.32) inset;
     border-bottom: 1px #ccc solid;
     background-color: rgba(208, 208, 208, 0.35);
+}
+
+.WebvizSettingsGroup__Content__Transition {
     transition: height 0.3s ease-in-out;
 }
 

--- a/react/src/lib/components/WebvizViewElement/webviz-view-element.css
+++ b/react/src/lib/components/WebvizViewElement/webviz-view-element.css
@@ -85,7 +85,7 @@
     align-items: center;
     z-index: 100;
     height: 24px;
-    border-radius: 8px;
+    border-radius: 12px;
 }
 
 .WebvizViewElement__Actions {


### PR DESCRIPTION
This PR introduces storing of `WLF` (active plugin, active view, settings drawer toggle state, opened settings groups) and `Menu` (open settings group which contains current page when initially loading) states in the browser's local storage. Moreover, if no URL path is given, the first page of the Webviz app is automatically opened.

Last but not least, settings groups do now remain open when other groups are toggled (independent state).