### PR TITLE
Settings dialog of view elements can now be controlled via tour steps (WLF)

### DIFF
--- a/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
+++ b/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
@@ -293,6 +293,7 @@ export const StoreReducer = (
     if (action.type === StoreActions.SetActiveView) {
         return {
             ...state,
+            openViewElementSettingsGroupId: null,
             pluginsData: [
                 ...state.pluginsData.map((plugin) =>
                     plugin.id === state.activePluginId

--- a/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
+++ b/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
@@ -64,8 +64,9 @@ export enum StoreActions {
     RemoveOpenSettingsGroupId = "remove_open_settings_group_id",
     SetSettingsDrawerOpen = "set_settings_drawer_open",
     IncrementViewUpdates = "increment_view_updated",
-    AddOpenViewElementSettingsGroupId = "add_open_view_element_settings_group_id",
-    RemoveOpenViewElementSettingsGroupId = "remove_open_view_element_settings_group_id",
+    AddOpenViewElementSettingsDialogId = "add_open_view_element_settings_dialog_id",
+    RemoveOpenViewElementSettingsDialogId = "remove_open_view_element_settings_dialog_id",
+    RemoveAllOpenViewElementSettingsDialogIds = "remove_all_open_view_element_settings_dialog_ids",
 }
 
 export type StoreState = {
@@ -75,7 +76,7 @@ export type StoreState = {
     pluginsData: PluginData[];
     activePluginWrapperRef: React.RefObject<HTMLDivElement> | null;
     openSettingsGroupIds: string[];
-    openViewElementSettingsGroupId: string | null;
+    openViewElementSettingsDialogIds: string[];
     settingsDrawerOpen: boolean;
     externalTrigger: boolean;
     backdropOpacity: number;
@@ -153,10 +154,13 @@ type Payload = {
         externalTrigger: boolean;
     };
     [StoreActions.IncrementViewUpdates]: null;
-    [StoreActions.AddOpenViewElementSettingsGroupId]: {
-        settingsGroupId: string;
+    [StoreActions.AddOpenViewElementSettingsDialogId]: {
+        settingsDialogId: string;
     };
-    [StoreActions.RemoveOpenViewElementSettingsGroupId]: undefined;
+    [StoreActions.RemoveOpenViewElementSettingsDialogId]: {
+        settingsDialogId: string;
+    };
+    [StoreActions.RemoveAllOpenViewElementSettingsDialogIds]: undefined;
 };
 
 export type Actions = ActionMap<Payload>[keyof ActionMap<Payload>];
@@ -169,7 +173,7 @@ const setInitialState = (): StoreState => {
         position: DrawerPosition.Left,
         activePluginWrapperRef: null,
         openSettingsGroupIds: [],
-        openViewElementSettingsGroupId: null,
+        openViewElementSettingsDialogIds: [],
         settingsDrawerOpen: false,
         backdropOpacity: 0,
         fullScreenActions: [],
@@ -293,7 +297,7 @@ export const StoreReducer = (
     if (action.type === StoreActions.SetActiveView) {
         return {
             ...state,
-            openViewElementSettingsGroupId: null,
+            openViewElementSettingsDialogIds: [],
             pluginsData: [
                 ...state.pluginsData.map((plugin) =>
                     plugin.id === state.activePluginId
@@ -320,7 +324,7 @@ export const StoreReducer = (
     if (action.type === StoreActions.SetActivePlugin) {
         return {
             ...state,
-            openViewElementSettingsGroupId: null,
+            openViewElementSettingsDialogIds: [],
             activePluginId: action.payload.pluginId,
         };
     }
@@ -398,16 +402,30 @@ export const StoreReducer = (
             viewUpdates: state.viewUpdates + 1,
         };
     }
-    if (action.type === StoreActions.AddOpenViewElementSettingsGroupId) {
+    if (action.type === StoreActions.AddOpenViewElementSettingsDialogId) {
         return {
             ...state,
-            openViewElementSettingsGroupId: action.payload.settingsGroupId,
+            openViewElementSettingsDialogIds: [
+                ...state.openViewElementSettingsDialogIds,
+                action.payload.settingsDialogId,
+            ],
         };
     }
-    if (action.type === StoreActions.RemoveOpenViewElementSettingsGroupId) {
+    if (action.type === StoreActions.RemoveOpenViewElementSettingsDialogId) {
         return {
             ...state,
-            openViewElementSettingsGroupId: null,
+            openViewElementSettingsDialogIds:
+                state.openViewElementSettingsDialogIds.filter(
+                    (el) => el !== action.payload.settingsDialogId
+                ),
+        };
+    }
+    if (
+        action.type === StoreActions.RemoveAllOpenViewElementSettingsDialogIds
+    ) {
+        return {
+            ...state,
+            openViewElementSettingsDialogIds: [],
         };
     }
     return state;

--- a/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
+++ b/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
@@ -318,7 +318,11 @@ export const StoreReducer = (
         };
     }
     if (action.type === StoreActions.SetActivePlugin) {
-        return { ...state, activePluginId: action.payload.pluginId };
+        return {
+            ...state,
+            openViewElementSettingsGroupId: null,
+            activePluginId: action.payload.pluginId,
+        };
     }
     if (action.type === StoreActions.SetMenuPosition) {
         let position = DrawerPosition.Left;

--- a/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
+++ b/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
@@ -17,22 +17,25 @@ import { TourStep } from "../../shared-types/webviz-content/tour-step";
 
 type ActionMap<
     M extends {
-        [index: string]: {
-            [key: string]:
-                | ContactPerson
-                | DeprecationWarning[]
-                | string
-                | Margins
-                | number
-                | null
-                | boolean
-                | React.RefObject<HTMLDivElement>
-                | View[]
-                | ((action: string) => void)
-                | FullScreenAction[]
-                | TourStep[]
-                | string[];
-        } | null;
+        [index: string]:
+            | {
+                  [key: string]:
+                      | ContactPerson
+                      | DeprecationWarning[]
+                      | string
+                      | Margins
+                      | number
+                      | null
+                      | boolean
+                      | React.RefObject<HTMLDivElement>
+                      | View[]
+                      | ((action: string) => void)
+                      | FullScreenAction[]
+                      | TourStep[]
+                      | string[];
+              }
+            | null
+            | undefined;
     }
 > = {
     [Key in keyof M]: M[Key] extends undefined
@@ -61,6 +64,8 @@ export enum StoreActions {
     RemoveOpenSettingsGroupId = "remove_open_settings_group_id",
     SetSettingsDrawerOpen = "set_settings_drawer_open",
     IncrementViewUpdates = "increment_view_updated",
+    AddOpenViewElementSettingsGroupId = "add_open_view_element_settings_group_id",
+    RemoveOpenViewElementSettingsGroupId = "remove_open_view_element_settings_group_id",
 }
 
 export type StoreState = {
@@ -70,6 +75,7 @@ export type StoreState = {
     pluginsData: PluginData[];
     activePluginWrapperRef: React.RefObject<HTMLDivElement> | null;
     openSettingsGroupIds: string[];
+    openViewElementSettingsGroupId: string | null;
     settingsDrawerOpen: boolean;
     externalTrigger: boolean;
     backdropOpacity: number;
@@ -147,6 +153,10 @@ type Payload = {
         externalTrigger: boolean;
     };
     [StoreActions.IncrementViewUpdates]: null;
+    [StoreActions.AddOpenViewElementSettingsGroupId]: {
+        settingsGroupId: string;
+    };
+    [StoreActions.RemoveOpenViewElementSettingsGroupId]: undefined;
 };
 
 export type Actions = ActionMap<Payload>[keyof ActionMap<Payload>];
@@ -159,6 +169,7 @@ const setInitialState = (): StoreState => {
         position: DrawerPosition.Left,
         activePluginWrapperRef: null,
         openSettingsGroupIds: [],
+        openViewElementSettingsGroupId: null,
         settingsDrawerOpen: false,
         backdropOpacity: 0,
         fullScreenActions: [],
@@ -380,6 +391,18 @@ export const StoreReducer = (
         return {
             ...state,
             viewUpdates: state.viewUpdates + 1,
+        };
+    }
+    if (action.type === StoreActions.AddOpenViewElementSettingsGroupId) {
+        return {
+            ...state,
+            openViewElementSettingsGroupId: action.payload.settingsGroupId,
+        };
+    }
+    if (action.type === StoreActions.RemoveOpenViewElementSettingsGroupId) {
+        return {
+            ...state,
+            openViewElementSettingsGroupId: null,
         };
     }
     return state;

--- a/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
+++ b/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
@@ -202,6 +202,23 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
                     },
                 });
             }
+
+            if (
+                store.state.openViewElementSettingsDialogIds.some(
+                    (el) =>
+                        el ===
+                        `${tourSteps[currentTourStep].viewElementId}-settings`
+                ) &&
+                tourSteps[currentTourStep].viewElementId !==
+                    tourSteps[newTourStep].viewElementId
+            ) {
+                store.dispatch({
+                    type: StoreActions.RemoveOpenViewElementSettingsDialogId,
+                    payload: {
+                        settingsDialogId: `${tourSteps[currentTourStep].viewElementId}-settings`,
+                    },
+                });
+            }
             if (
                 tourSteps[newTourStep].viewElementId &&
                 tourSteps[newTourStep].settingsGroupId &&
@@ -222,22 +239,6 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
                     () => setCurrentTourStep(newTourStep)
                 );
                 return;
-            }
-            if (
-                store.state.openViewElementSettingsDialogIds.some(
-                    (el) =>
-                        el ===
-                        `${tourSteps[currentTourStep].viewElementId}-settings`
-                ) &&
-                tourSteps[currentTourStep].viewElementId !==
-                    tourSteps[newTourStep].viewElementId
-            ) {
-                store.dispatch({
-                    type: StoreActions.RemoveOpenViewElementSettingsDialogId,
-                    payload: {
-                        settingsDialogId: `${tourSteps[currentTourStep].viewElementId}-settings`,
-                    },
-                });
             }
 
             setCurrentTourStep(newTourStep);

--- a/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
+++ b/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
@@ -7,37 +7,13 @@ import { Icon } from "@equinor/eds-core-react";
 import { arrow_back, arrow_forward } from "@equinor/eds-icons";
 Icon.add({ arrow_back, arrow_forward });
 
+import { waitUntilElementIsAvailable } from "../../utils/waitUntilElementIsAvailable";
 import "./webviz-plugin-tour.css";
 import { Point } from "lib/shared-types/point";
 
 export type WebvizPluginTourProps = {
     open: boolean;
     onClose: () => void;
-};
-
-const waitUntilElementIsAvailable = (
-    query: string,
-    callback: () => void,
-    timestepMs = 100,
-    maxWaitTimeMs = 5000
-) => {
-    let intervalId: ReturnType<typeof setInterval> | null = null;
-    let passedTimeMs = 0;
-    const checkIfElementIsAvailable = () => {
-        const element = document.getElementById(query);
-        if (element) {
-            if (intervalId) {
-                clearInterval(intervalId);
-            }
-            callback();
-        }
-        passedTimeMs += timestepMs;
-        if (passedTimeMs >= maxWaitTimeMs && intervalId) {
-            clearInterval(intervalId);
-        }
-    };
-    intervalId = setInterval(checkIfElementIsAvailable, timestepMs);
-    checkIfElementIsAvailable();
 };
 
 export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
@@ -235,7 +211,7 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
                     },
                 });
                 waitUntilElementIsAvailable(
-                    `${tourSteps[newTourStep].elementId}`,
+                    tourSteps[newTourStep].elementId,
                     () => setCurrentTourStep(newTourStep)
                 );
                 return;

--- a/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
+++ b/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
@@ -93,6 +93,9 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
     React.useEffect(() => {
         if (props.open && tourSteps) {
             handleChangeTourStep(0);
+            store.dispatch({
+                type: StoreActions.RemoveAllOpenViewElementSettingsDialogIds,
+            });
             return;
         }
         if (intervalRef.current) {
@@ -201,13 +204,17 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
             }
             if (
                 tourSteps[newTourStep].viewElementId &&
-                tourSteps[newTourStep].settingsGroupId
+                tourSteps[newTourStep].settingsGroupId &&
+                !store.state.openViewElementSettingsDialogIds.some(
+                    (el) =>
+                        el ===
+                        `${tourSteps[newTourStep].viewElementId}-settings`
+                )
             ) {
                 store.dispatch({
-                    type: StoreActions.AddOpenViewElementSettingsGroupId,
+                    type: StoreActions.AddOpenViewElementSettingsDialogId,
                     payload: {
-                        settingsGroupId:
-                            tourSteps[newTourStep].settingsGroupId || "",
+                        settingsDialogId: `${tourSteps[newTourStep].viewElementId}-settings`,
                     },
                 });
                 waitUntilElementIsAvailable(
@@ -215,15 +222,27 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
                     () => setCurrentTourStep(newTourStep)
                 );
                 return;
-            } else {
+            }
+            if (
+                store.state.openViewElementSettingsDialogIds.some(
+                    (el) =>
+                        el ===
+                        `${tourSteps[currentTourStep].viewElementId}-settings`
+                ) &&
+                tourSteps[currentTourStep].viewElementId !==
+                    tourSteps[newTourStep].viewElementId
+            ) {
                 store.dispatch({
-                    type: StoreActions.RemoveOpenViewElementSettingsGroupId,
+                    type: StoreActions.RemoveOpenViewElementSettingsDialogId,
+                    payload: {
+                        settingsDialogId: `${tourSteps[currentTourStep].viewElementId}-settings`,
+                    },
                 });
             }
 
             setCurrentTourStep(newTourStep);
         },
-        [tourSteps, pluginData?.activeViewId]
+        [tourSteps, currentTourStep, pluginData?.activeViewId, store]
     );
 
     return ReactDOM.createPortal(

--- a/react/src/lib/components/WebvizPluginWrapper/WebvizPluginWrapper.tsx
+++ b/react/src/lib/components/WebvizPluginWrapper/WebvizPluginWrapper.tsx
@@ -94,11 +94,13 @@ export const WebvizPluginWrapper: React.FC<WebvizPluginWrapperProps> = (
     }, [store.state.activePluginId, props.id]);
 
     const handlePluginClick = React.useCallback(() => {
-        store.dispatch({
-            type: StoreActions.SetActivePlugin,
-            payload: { pluginId: props.id },
-        });
-    }, [props.id]);
+        if (store.state.activePluginId !== props.id) {
+            store.dispatch({
+                type: StoreActions.SetActivePlugin,
+                payload: { pluginId: props.id },
+            });
+        }
+    }, [props.id, store]);
 
     return (
         <div

--- a/react/src/lib/components/WebvizViewElement/WebvizViewElement.tsx
+++ b/react/src/lib/components/WebvizViewElement/WebvizViewElement.tsx
@@ -80,6 +80,8 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
     const flashAnimation =
         React.useRef<Animation<FlashAnimationParameters> | null>(null);
 
+    const settingsDialogId = `${props.id}-settings`;
+
     React.useEffect(() => {
         if (props.download !== null && props.download !== undefined) {
             downloadFile({
@@ -475,13 +477,41 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
         return null;
     }
 
-    React.useEffect(() => {
-        if (store.state.openViewElementSettingsGroupId === null) {
-            setSettingsVisible(false);
+    React.useLayoutEffect(() => {
+        if (
+            store.state.openViewElementSettingsDialogIds.some(
+                (el) => el === settingsDialogId
+            )
+        ) {
+            setSettingsVisible(true);
             return;
         }
-        setSettingsVisible(true);
-    }, [store.state.openViewElementSettingsGroupId]);
+        setSettingsVisible(false);
+    }, [store.state.openViewElementSettingsDialogIds, settingsDialogId]);
+
+    const handleOpenSettingsDialog = React.useCallback(() => {
+        if (
+            !store.state.openViewElementSettingsDialogIds.some(
+                (el) => el === settingsDialogId
+            )
+        ) {
+            store.dispatch({
+                type: StoreActions.AddOpenViewElementSettingsDialogId,
+                payload: {
+                    settingsDialogId: settingsDialogId,
+                },
+            });
+        }
+    }, [store, settingsDialogId]);
+
+    const handleCloseSettingsDialog = React.useCallback(() => {
+        store.dispatch({
+            type: StoreActions.RemoveOpenViewElementSettingsDialogId,
+            payload: {
+                settingsDialogId: settingsDialogId,
+            },
+        });
+    }, [store, settingsDialogId]);
 
     return (
         <div
@@ -521,7 +551,7 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
                     <div>
                         <Tooltip title="Open settings for view element">
                             <IconButton
-                                onClick={() => setSettingsVisible(true)}
+                                onClick={() => handleOpenSettingsDialog()}
                             >
                                 <Icon name="settings" size={16} />
                             </IconButton>
@@ -554,7 +584,7 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
                 </div>
             </div>
             <Dialog
-                id={`${props.id}-settings`}
+                id={settingsDialogId}
                 title="View Element Settings"
                 open={settingsVisible}
                 draggable={true}
@@ -564,7 +594,7 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
                     action_called: number;
                 }) => {
                     if (dialogProps.open === false) {
-                        setSettingsVisible(false);
+                        handleCloseSettingsDialog();
                     }
                 }}
             >

--- a/react/src/lib/components/WebvizViewElement/WebvizViewElement.tsx
+++ b/react/src/lib/components/WebvizViewElement/WebvizViewElement.tsx
@@ -59,6 +59,8 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
     const store = useStore();
     //const [isLoading, setIsLoading] = React.useState<boolean>(false);
     const [isHovered, setIsHovered] = React.useState<boolean>(false);
+    const [settings, setSettings] = React.useState<React.ReactElement[]>([]);
+    const [content, setContent] = React.useState<React.ReactNode[]>([]);
     const [settingsVisible, setSettingsVisible] =
         React.useState<boolean>(false);
     const [isFullScreen, setIsFullScreen] = React.useState<boolean>(false);
@@ -440,29 +442,26 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
         }
     };
 
-    const settings: React.ReactElement[] = [];
-    const content: React.ReactNode[] = [];
-
     React.useEffect(() => {
-        if (store.state.openViewElementSettingsGroupId === null) {
-            setSettingsVisible(false);
-            return;
-        }
-        setSettingsVisible(true);
-    }, [store.state.openViewElementSettingsGroupId]);
+        const settings: React.ReactElement[] = [];
+        const content: React.ReactNode[] = [];
 
-    React.Children.forEach(props.children, (child) => {
-        if (
-            React.isValidElement(child) &&
-            typeof child.props === "object" &&
-            Object.keys(child.props).includes("_dashprivate_layout") &&
-            child.props._dashprivate_layout.type === "WebvizSettingsGroup"
-        ) {
-            settings.push(child);
-            return;
-        }
-        content.push(child);
-    });
+        React.Children.forEach(props.children, (child) => {
+            if (
+                React.isValidElement(child) &&
+                typeof child.props === "object" &&
+                Object.keys(child.props).includes("_dashprivate_layout") &&
+                child.props._dashprivate_layout.type === "WebvizSettingsGroup"
+            ) {
+                settings.push(child);
+                return;
+            }
+            content.push(child);
+        });
+
+        setSettings(settings);
+        setContent(content);
+    }, [props.children]);
 
     const handleDownloadClick = React.useCallback(() => {
         const requests = downloadRequests + 1;
@@ -475,6 +474,14 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
     if (props.hidden) {
         return null;
     }
+
+    React.useEffect(() => {
+        if (store.state.openViewElementSettingsGroupId === null) {
+            setSettingsVisible(false);
+            return;
+        }
+        setSettingsVisible(true);
+    }, [store.state.openViewElementSettingsGroupId]);
 
     return (
         <div

--- a/react/src/lib/components/WebvizViewElement/WebvizViewElement.tsx
+++ b/react/src/lib/components/WebvizViewElement/WebvizViewElement.tsx
@@ -443,6 +443,14 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
     const settings: React.ReactElement[] = [];
     const content: React.ReactNode[] = [];
 
+    React.useEffect(() => {
+        if (store.state.openViewElementSettingsGroupId === null) {
+            setSettingsVisible(false);
+            return;
+        }
+        setSettingsVisible(true);
+    }, [store.state.openViewElementSettingsGroupId]);
+
     React.Children.forEach(props.children, (child) => {
         if (
             React.isValidElement(child) &&

--- a/react/src/lib/utils/waitUntilElementIsAvailable.ts
+++ b/react/src/lib/utils/waitUntilElementIsAvailable.ts
@@ -1,0 +1,24 @@
+export const waitUntilElementIsAvailable = (
+    query: string,
+    callback: () => void,
+    timestepMs = 100,
+    maxWaitTimeMs = 5000
+) => {
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let passedTimeMs = 0;
+    const checkIfElementIsAvailable = () => {
+        const element = document.getElementById(query);
+        if (element) {
+            if (intervalId) {
+                clearInterval(intervalId);
+            }
+            callback();
+        }
+        passedTimeMs += timestepMs;
+        if (passedTimeMs >= maxWaitTimeMs && intervalId) {
+            clearInterval(intervalId);
+        }
+    };
+    intervalId = setInterval(checkIfElementIsAvailable, timestepMs);
+    checkIfElementIsAvailable();
+};


### PR DESCRIPTION
The `SettingsGroup` placed within a `wcc.Dialog` in the `WebvizViewElement` in `WLF` were not shown during tour steps.

Control added to tour steps and `WebvizViewElement`

---
Resolves issue: https://github.com/equinor/webviz-core-components/issues/246