### PR TITLE
Added missing `id` and `key` props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   [#219](https://github.com/equinor/webviz-core-components/pull/219) - Implemented components required by the new Webviz Layout Framework (WLF)
 -   [#227](https://github.com/equinor/webviz-core-components/pull/227) - Added `EdsIcon` component in order to use icons from the Equinor Design System (EDS) directly in Python.
 -   [#240](https://github.com/equinor/webviz-core-components/pull/240) - States of menu, active view, settings drawer and settings groups are getting stored now. If no URL path is given, the one of the first page is opened now.
+-   [#248](https://github.com/equinor/webviz-core-components/pull/248) - Added missing `id` in `WebvizSettingsGroup` and `key` in `WebvizViewList` (for view groups).
 
 ### Changed
 

--- a/react/src/lib/components/WebvizSettingsDrawer/components/ViewList/view-list.tsx
+++ b/react/src/lib/components/WebvizSettingsDrawer/components/ViewList/view-list.tsx
@@ -126,7 +126,10 @@ export const ViewList: React.FC<ViewListProps> = (props: ViewListProps) => {
                         );
                     } else {
                         return (
-                            <div className="WebvizViewList__Group">
+                            <div
+                                className="WebvizViewList__Group"
+                                key={el.group}
+                            >
                                 <div className="WebvizViewList__GroupTitle">
                                     {el.group}
                                 </div>

--- a/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
+++ b/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
@@ -133,6 +133,7 @@ export const WebvizSettingsGroup: React.FC<WebvizSettingsGroupProps> = (
 
     return (
         <div
+            id={props.id}
             className="WebvizSettingsGroup"
             style={{ display: visible ? "block" : "none" }}
         >


### PR DESCRIPTION
Added `id` to `SettingsGroup` and `key` to `WebivzViewList__Group`. This is especially important for opening settings groups in Python tests.