### PR TITLE
Refactored `Menu` component to make it work in sync with `dcc.Location`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   [#219](https://github.com/equinor/webviz-core-components/pull/219) - Pinned `dash` version to `2.4.x`, added more info output to GitHub workflow, switched to React version `16.14.0` in order to comply with non-maintained `react-colorscales` requirements, implemented adjustments to `Overlay` and `ScrollArea`
 -   [#240](https://github.com/equinor/webviz-core-components/pull/240) - Settings groups remain open when others are toggled (independent toggle state).
 -   [#243](https://github.com/equinor/webviz-core-components/pull/243) - Added debounce time for `Select` component to prevent firing selected values immediately. The selected values will be updated after configured amount of milliseconds after last interaction. Reduces number of callback triggers in Dash.
+-   [#252](https://github.com/equinor/webviz-core-components/pull/252) - Refactored `Menu` component in order to make it work seamlessly with `dcc.Location` and `dcc.Link`.
 
 ## [0.5.7] - 2022-05-05
 

--- a/react/src/demo/App.tsx
+++ b/react/src/demo/App.tsx
@@ -9,7 +9,12 @@
 import { Button } from "@material-ui/core";
 import React from "react";
 
-import { WebvizPluginPlaceholder, SmartNodeSelector, Dialog } from "../lib";
+import {
+    WebvizPluginPlaceholder,
+    SmartNodeSelector,
+    Dialog,
+    Menu,
+} from "../lib";
 
 const steps = [
     {
@@ -28,10 +33,6 @@ type SmartNodeSelectorProps = {
     selectedIds: string[];
 };
 
-type MenuProps = {
-    url: string;
-};
-
 const App: React.FC = () => {
     const [nodeSelectorState, setNodeSelectorState] =
         React.useState<SmartNodeSelectorProps>({
@@ -40,15 +41,50 @@ const App: React.FC = () => {
             selectedTags: [],
         });
 
-    const [currentPage, setCurrentPage] = React.useState<MenuProps>({
-        url: "",
-    });
-
     const [dialogOpen, setDialogOpen] = React.useState<boolean>(false);
+    const [currentPage, setCurrentPage] = React.useState<string>(
+        window.location.hash.replace("#", "")
+    );
+
+    React.useEffect(() => {
+        const handleLocationChange = () => {
+            setCurrentPage(window.location.hash.replace("#", ""));
+        };
+
+        window.addEventListener("popstate", handleLocationChange);
+        window.addEventListener("_dashprivate_pushstate", handleLocationChange);
+
+        return () => {
+            window.removeEventListener("popstate", handleLocationChange);
+            window.removeEventListener(
+                "_dashprivate_pushstate",
+                handleLocationChange
+            );
+        };
+    }, []);
 
     return (
         <div>
-            {currentPage.url.split("#")[1] === "dialog" && (
+            <Menu
+                navigationItems={[
+                    {
+                        type: "page",
+                        title: "Dialog",
+                        href: "#dialog",
+                    },
+                    {
+                        type: "page",
+                        title: "Plugin placeholder",
+                        href: "#webviz-plugin-placeholder",
+                    },
+                    {
+                        type: "page",
+                        title: "SmartNodeSelector",
+                        href: "#smart-node-selector",
+                    },
+                ]}
+            />
+            {currentPage === "dialog" && (
                 <>
                     <h1>Dialog</h1>
                     <Button
@@ -76,7 +112,7 @@ const App: React.FC = () => {
                     </Dialog>
                 </>
             )}
-            {currentPage.url.split("#")[1] === "webviz-plugin-placeholder" && (
+            {currentPage === "webviz-plugin-placeholder" && (
                 <>
                     <h1>WebvizPluginPlaceholder</h1>
                     <WebvizPluginPlaceholder
@@ -102,7 +138,7 @@ const App: React.FC = () => {
                     />
                 </>
             )}
-            {currentPage.url.split("#")[1] === "smart-node-selector" && (
+            {currentPage === "smart-node-selector" && (
                 <>
                     <h1>SmartNodeSelector</h1>
                     <SmartNodeSelector

--- a/react/src/lib/components/Menu/Menu.stories.tsx
+++ b/react/src/lib/components/Menu/Menu.stories.tsx
@@ -51,5 +51,4 @@ Basic.args = {
     menuBarPosition: Menu.defaultProps?.menuBarPosition || "left",
     menuDrawerPosition: Menu.defaultProps?.menuDrawerPosition || "left",
     showLogo: Menu.defaultProps?.showLogo || true,
-    url: Menu.defaultProps?.url || "",
 };

--- a/react/src/lib/components/Menu/Menu.tsx
+++ b/react/src/lib/components/Menu/Menu.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import useSize from "@react-hook/size";
 
-import { useStore } from "../WebvizContentManager";
+import { useStore as useWebvizStore } from "../WebvizContentManager";
 
 import { TopMenu } from "./components/TopMenu/TopMenu";
 import { MenuBar } from "./components/MenuBar/MenuBar";
@@ -28,10 +28,6 @@ import "./Menu.css";
 import { StoreActions } from "../WebvizContentManager/WebvizContentManager";
 import { Margins } from "lib/shared-types/margins";
 
-export type ParentProps = {
-    url: string;
-};
-
 export type MenuProps = {
     id?: string;
     navigationItems: PropertyNavigationType;
@@ -40,8 +36,7 @@ export type MenuProps = {
     menuBarPosition?: "top" | "left" | "right" | "bottom";
     menuDrawerPosition?: "left" | "right";
     showLogo?: boolean;
-    url?: string;
-    setProps?: (props: ParentProps) => void;
+    homepageUrl?: string;
 };
 
 const calculateTextWidth = (text: string): number => {
@@ -62,12 +57,15 @@ const calculateTextWidth = (text: string): number => {
 
 const makeNavigationItemsWithAssignedIds = (
     navigationItems: PropertyNavigationType
-): NavigationType => {
+): { navigationItems: NavigationType; firstPageHref: string } => {
     const indices = {
         section: 0,
         group: 0,
         page: 0,
     };
+
+    let firstPageHref: string | null = null;
+
     const recursivelyAssignUuids = (
         item: PropertyPageType | PropertyGroupType | PropertySectionType
     ): GroupType | PageType | SectionType => {
@@ -81,6 +79,9 @@ const makeNavigationItemsWithAssignedIds = (
                 id: `group-${indices.group++}`,
             };
         } else if (item.type === "page") {
+            if (firstPageHref === null) {
+                firstPageHref = item.href;
+            }
             return {
                 ...item,
                 type: "page",
@@ -97,10 +98,13 @@ const makeNavigationItemsWithAssignedIds = (
             };
         }
     };
-    return navigationItems.map(
-        (el: PropertySectionType | PropertyGroupType | PropertyPageType) =>
-            recursivelyAssignUuids(el)
-    ) as NavigationType;
+    return {
+        navigationItems: navigationItems.map(
+            (el: PropertySectionType | PropertyGroupType | PropertyPageType) =>
+                recursivelyAssignUuids(el)
+        ) as NavigationType,
+        firstPageHref: firstPageHref || "",
+    };
 };
 
 const getNavigationMaxWidth = (
@@ -136,30 +140,12 @@ const getNavigationMaxWidth = (
     return recursivelyParseItems(navigationItems);
 };
 
-const getStartPage = (
-    navigationItems: PropertyNavigationType
-): PropertyPageType | null => {
-    let startPage: PropertyPageType | null = null;
-    let abort = false;
-    const recursivelyParseItems = (
-        items: (PropertyPageType | PropertyGroupType | PropertySectionType)[]
-    ) => {
-        items.forEach((item) => {
-            if (abort) {
-                return;
-            }
-            if (item.type !== "page") {
-                recursivelyParseItems(item.content);
-            } else {
-                abort = true;
-                startPage = item as PropertyPageType;
-                return;
-            }
-        });
-    };
-    recursivelyParseItems(navigationItems);
-    return startPage;
+type MenuContext = {
+    homepage: string;
+    firstPageHref: string;
 };
+
+const menuContext = React.createContext<MenuContext | undefined>(undefined);
 
 /**
  * Menu is a component that allows to create an interactive menu with flexible depth that
@@ -170,7 +156,7 @@ export const Menu: React.FC<MenuProps> = (props) => {
     const menuDrawerPosition = props.menuDrawerPosition || "left";
     const showLogo = props.showLogo || false;
 
-    const webvizContentStore = useStore();
+    const webvizContentStore = useWebvizStore();
 
     const [open, setOpen] = React.useState<boolean>(false);
     const [pinned, setPinned] = React.useState<boolean>(
@@ -181,22 +167,16 @@ export const Menu: React.FC<MenuProps> = (props) => {
     const [currentUrl, setCurrentUrl] = React.useState<string>(
         window.location.href
     );
-
-    const [firstPage, setFirstPage] =
-        React.useState<PropertyPageType | null>(null);
-
-    React.useEffect(() => {
-        setFirstPage(getStartPage(props.navigationItems));
-    }, []);
+    const [firstPageHref, setFirstPageHref] = React.useState<string>(
+        props.homepageUrl || ""
+    );
 
     const [menuWidth, setMenuWidth] = React.useState<number>(
         getNavigationMaxWidth(props.navigationItems) + 40
     );
 
     const [navigationItemsWithAssignedIds, setNavigationsItemsWithAssignedIds] =
-        React.useState<NavigationType>(
-            makeNavigationItemsWithAssignedIds(props.navigationItems)
-        );
+        React.useState<NavigationType>([]);
 
     React.useEffect(() => {
         localStorage.setItem("pinned", pinned ? "true" : "false");
@@ -212,8 +192,13 @@ export const Menu: React.FC<MenuProps> = (props) => {
     const menuPadding = 32;
 
     React.useEffect(() => {
+        const navigationItemsAndFirstPageHref =
+            makeNavigationItemsWithAssignedIds(props.navigationItems);
         setNavigationsItemsWithAssignedIds(
-            makeNavigationItemsWithAssignedIds(props.navigationItems)
+            navigationItemsAndFirstPageHref.navigationItems
+        );
+        setFirstPageHref(
+            props.homepageUrl || navigationItemsAndFirstPageHref.firstPageHref
         );
         setMenuWidth(
             Math.max(
@@ -225,7 +210,7 @@ export const Menu: React.FC<MenuProps> = (props) => {
                 )
             )
         );
-    }, [props.navigationItems, windowSize.width]);
+    }, [props.navigationItems, windowSize.width, props.homepageUrl]);
 
     React.useEffect(() => {
         const bodyMargins: Margins = {
@@ -278,71 +263,76 @@ export const Menu: React.FC<MenuProps> = (props) => {
         menuDrawerPosition,
     ]);
 
-    const handlePageChange = React.useCallback(
-        (url: string) => {
-            setOpen(false);
-            setTimeout(() => {
-                props.setProps && props.setProps({ url: url });
-                window.history.pushState({}, "", url);
-                setCurrentUrl(url);
-            }, 350);
-        },
-        [setOpen]
-    );
+    React.useEffect(() => {
+        const handleLocationChange = () => {
+            setCurrentUrl(window.location.href);
+        };
+
+        window.addEventListener("popstate", handleLocationChange);
+        window.addEventListener("_dashprivate_pushstate", handleLocationChange);
+
+        return () => {
+            window.removeEventListener("popstate", handleLocationChange);
+            window.removeEventListener(
+                "_dashprivate_pushstate",
+                handleLocationChange
+            );
+        };
+    }, []);
 
     return (
-        <div className="Menu" id={props.id}>
-            <Overlay visible={open && !pinned} onClick={() => setOpen(false)} />
-            <MenuBar
-                position={menuBarPosition as MenuBarPosition}
-                menuButtonPosition={menuDrawerPosition as MenuDrawerPosition}
-                visible={!pinned}
-                onMenuOpen={() => setOpen(true)}
-                ref={menuBarRef}
-                homepage={"/"}
-                showLogo={showLogo}
-                onLogoClick={handlePageChange}
-            />
-            <MenuDrawer
-                position={menuDrawerPosition as MenuDrawerPosition}
-                open={open || pinned}
-                pinned={pinned}
-                ref={menuDrawerRef}
-                maxWidth={menuWidth}
-                currentUrl={currentUrl}
-            >
-                <TopMenu
+        <menuContext.Provider
+            value={{
+                homepage: props.homepageUrl || "",
+                firstPageHref: firstPageHref,
+            }}
+        >
+            <div className="Menu" id={props.id}>
+                <Overlay
+                    visible={open && !pinned}
+                    onClick={() => setOpen(false)}
+                />
+                <MenuBar
+                    position={menuBarPosition as MenuBarPosition}
+                    menuButtonPosition={
+                        menuDrawerPosition as MenuDrawerPosition
+                    }
+                    visible={!pinned}
+                    onMenuOpen={() => setOpen(true)}
+                    ref={menuBarRef}
+                    showLogo={showLogo}
+                />
+                <MenuDrawer
+                    position={menuDrawerPosition as MenuDrawerPosition}
+                    open={open || pinned}
                     pinned={pinned}
-                    onPinnedChange={() => setPinned(!pinned)}
-                />
-                {showLogo && (
-                    <Logo
-                        onClick={handlePageChange}
-                        homepage={firstPage?.href || "/"}
-                        size="large"
+                    ref={menuDrawerRef}
+                    maxWidth={menuWidth}
+                    currentUrl={currentUrl}
+                >
+                    <TopMenu
+                        pinned={pinned}
+                        onPinnedChange={() => setPinned(!pinned)}
                     />
-                )}
-                <MenuContent
-                    content={navigationItemsWithAssignedIds}
-                    groupsInitiallyCollapsed={props.initiallyCollapsed}
-                    onPageChange={handlePageChange}
-                />
-            </MenuDrawer>
-        </div>
+                    {showLogo && <Logo size="large" />}
+                    <MenuContent
+                        content={navigationItemsWithAssignedIds}
+                        groupsInitiallyCollapsed={props.initiallyCollapsed}
+                    />
+                </MenuDrawer>
+            </div>
+        </menuContext.Provider>
     );
 };
+
+export const useStore = (): MenuContext =>
+    React.useContext<MenuContext>(menuContext as React.Context<MenuContext>);
 
 Menu.propTypes = {
     /**
      * The ID used to identify this component in Dash callbacks
      */
     id: PropTypes.string,
-
-    /**
-     * Dash-assigned callback that should be called whenever any of the
-     * properties change
-     */
-    setProps: PropTypes.func,
 
     /**
      * Set to true if the menu shall be initially shown as pinned.
@@ -375,19 +365,15 @@ Menu.propTypes = {
     navigationItems: PropTypes.any.isRequired,
 
     /**
-     * Currently selected URL. Leave blank.
+     * URL to be shown when clicking on the logo. If not defined, the first page will be used.
      */
-    url: PropTypes.string,
+    homepageUrl: PropTypes.string,
 };
 
 Menu.defaultProps = {
     id: "some-id",
-    setProps: () => {
-        return;
-    },
     initiallyPinned: false,
     showLogo: true,
     menuBarPosition: "left",
     menuDrawerPosition: "left",
-    url: "",
 };

--- a/react/src/lib/components/Menu/components/Logo/Logo.tsx
+++ b/react/src/lib/components/Menu/components/Logo/Logo.tsx
@@ -1,15 +1,22 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import { useStore } from "../../Menu";
+
 import "./Logo.css";
 
 type LogoProps = {
     size: "small" | "large";
-    homepage: string;
-    onClick: (url: string) => void;
 };
 
 export const Logo: React.FC<LogoProps> = (props) => {
+    const store = useStore();
+
+    const handleLogoClick = () => {
+        window.history.pushState({}, "", store.homepage);
+        window.dispatchEvent(new CustomEvent("_dashprivate_pushstate"));
+        window.scrollTo(0, 0);
+    };
     return (
         <div
             className={`Menu__Logo${
@@ -17,12 +24,12 @@ export const Logo: React.FC<LogoProps> = (props) => {
             }`}
         >
             <a
-                href={props.homepage}
+                href={store.homepage}
                 id={`Logo${
-                    props.size.charAt(0).toUpperCase() + props.size.substr(1)
+                    props.size.charAt(0).toUpperCase() + props.size.substring(1)
                 }`}
                 onClick={(e: React.MouseEvent<HTMLAnchorElement>) => {
-                    props.onClick(props.homepage);
+                    handleLogoClick();
                     e.preventDefault();
                 }}
             ></a>
@@ -32,6 +39,4 @@ export const Logo: React.FC<LogoProps> = (props) => {
 
 Logo.propTypes = {
     size: PropTypes.oneOf<"small" | "large">(["small", "large"]).isRequired,
-    homepage: PropTypes.string.isRequired,
-    onClick: PropTypes.func.isRequired,
 };

--- a/react/src/lib/components/Menu/components/Logo/Logo.tsx
+++ b/react/src/lib/components/Menu/components/Logo/Logo.tsx
@@ -13,7 +13,7 @@ export const Logo: React.FC<LogoProps> = (props) => {
     const store = useStore();
 
     const handleLogoClick = () => {
-        window.history.pushState({}, "", store.homepage);
+        window.history.pushState({}, "", store.homepage || store.firstPageHref);
         window.dispatchEvent(new CustomEvent("_dashprivate_pushstate"));
         window.scrollTo(0, 0);
     };

--- a/react/src/lib/components/Menu/components/MenuBar/MenuBar.tsx
+++ b/react/src/lib/components/Menu/components/MenuBar/MenuBar.tsx
@@ -16,9 +16,7 @@ type MenuBarProps = {
     menuButtonPosition: MenuDrawerPosition;
     visible: boolean;
     showLogo: boolean;
-    homepage: string;
     onMenuOpen: () => void;
-    onLogoClick: (url: string) => void;
 };
 
 type Position = {
@@ -316,13 +314,7 @@ export const MenuBar = React.forwardRef<HTMLDivElement, MenuBarProps>(
                     bottom: position.bottom,
                 }}
             >
-                {props.showLogo && (
-                    <Logo
-                        onClick={props.onLogoClick}
-                        homepage={props.homepage}
-                        size="small"
-                    />
-                )}
+                {props.showLogo && <Logo size="small" />}
                 <div
                     style={{
                         flexGrow: 1,
@@ -362,7 +354,5 @@ MenuBar.propTypes = {
     ]).isRequired,
     visible: PropTypes.bool.isRequired,
     showLogo: PropTypes.bool.isRequired,
-    homepage: PropTypes.string.isRequired,
     onMenuOpen: PropTypes.func.isRequired,
-    onLogoClick: PropTypes.func.isRequired,
 };

--- a/react/src/lib/components/Menu/components/MenuContent/MenuContent.tsx
+++ b/react/src/lib/components/Menu/components/MenuContent/MenuContent.tsx
@@ -114,7 +114,6 @@ const makeNavigation = (
     navigation: NavigationType,
     filtered: boolean,
     initiallyCollapsed: boolean,
-    homepage: string,
     firstPageHref: string
 ): JSX.Element => {
     const recursivelyMakeNavigation = (
@@ -168,7 +167,6 @@ const makeNavigation = (
                             <Page
                                 key={item.id}
                                 level={level}
-                                homepage={homepage}
                                 firstPage={
                                     (item as PageType).href === firstPageHref
                                 }
@@ -228,7 +226,6 @@ export const MenuContent: React.FC<MenuContentProps> = (props) => {
                         content,
                         filter !== "",
                         props.groupsInitiallyCollapsed || false,
-                        store.homepage,
                         store.firstPageHref
                     )
                 )}

--- a/react/src/lib/components/Menu/components/Page/Page.tsx
+++ b/react/src/lib/components/Menu/components/Page/Page.tsx
@@ -5,6 +5,7 @@ import { Icon } from "../Icon";
 import { checkIfUrlIsCurrent } from "../../utils/check-url";
 
 import "./Page.css";
+import { useStore } from "../../Menu";
 
 type PageProps = {
     title: string;
@@ -12,15 +13,15 @@ type PageProps = {
     level: number;
     icon?: string;
     applyIconIndentation: boolean;
-    homepage: string;
     firstPage: boolean;
     onClick: () => void;
 };
 
 export const Page: React.FC<PageProps> = (props) => {
+    const store = useStore();
     const active =
         checkIfUrlIsCurrent(props.href) ||
-        (props.firstPage && checkIfUrlIsCurrent(props.homepage));
+        (props.firstPage && checkIfUrlIsCurrent(store.homepage));
 
     return (
         <a
@@ -59,7 +60,7 @@ export const Page: React.FC<PageProps> = (props) => {
 Page.propTypes = {
     title: PropTypes.string.isRequired,
     href: PropTypes.string.isRequired,
-    homepage: PropTypes.string.isRequired,
+    firstPage: PropTypes.bool.isRequired,
     level: PropTypes.number.isRequired,
     icon: PropTypes.string,
     applyIconIndentation: PropTypes.bool.isRequired,

--- a/react/src/lib/components/Menu/components/Page/Page.tsx
+++ b/react/src/lib/components/Menu/components/Page/Page.tsx
@@ -12,11 +12,15 @@ type PageProps = {
     level: number;
     icon?: string;
     applyIconIndentation: boolean;
+    homepage: string;
+    firstPage: boolean;
     onClick: () => void;
 };
 
 export const Page: React.FC<PageProps> = (props) => {
-    const active = checkIfUrlIsCurrent(props.href);
+    const active =
+        checkIfUrlIsCurrent(props.href) ||
+        (props.firstPage && checkIfUrlIsCurrent(props.homepage));
 
     return (
         <a
@@ -55,6 +59,7 @@ export const Page: React.FC<PageProps> = (props) => {
 Page.propTypes = {
     title: PropTypes.string.isRequired,
     href: PropTypes.string.isRequired,
+    homepage: PropTypes.string.isRequired,
     level: PropTypes.number.isRequired,
     icon: PropTypes.string,
     applyIconIndentation: PropTypes.bool.isRequired,


### PR DESCRIPTION
`Menu` does no longer support a `setProps` prop - hence, the callbacks can no longer subscribe to its `url` property. In order to react to changes of the current location, use `dcc.Location`.