### PR TITLE
Now shows homepage as first page when given

### DIFF
--- a/react/src/lib/components/Menu/Menu.tsx
+++ b/react/src/lib/components/Menu/Menu.tsx
@@ -264,6 +264,13 @@ export const Menu: React.FC<MenuProps> = (props) => {
     ]);
 
     React.useEffect(() => {
+        if (props.homepageUrl) {
+            setCurrentUrl(props.homepageUrl);
+            window.history.pushState({}, "", props.homepageUrl);
+            window.dispatchEvent(new CustomEvent("_dashprivate_pushstate"));
+            window.scrollTo(0, 0);
+        }
+
         const handleLocationChange = () => {
             setCurrentUrl(window.location.href);
         };


### PR DESCRIPTION
Before, when a `homepageUrl` was given, it was not automatically set on start up.