### PR TITLE
Adjust ignores for `.vscode` folder in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,11 +20,8 @@ react/dist/
 
 # Created by .ignore support plugin (hsz.mobi)
 ### VisualStudioCode template
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
+.vscode/
+
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839


### PR DESCRIPTION
Adjust `.gitignore` for `.vscode` as developers might want various settings, launch, extensions, etc.

Closes: https://github.com/equinor/webviz-core-components/issues/266