### PR TITLE
Fixed bug in `Select` component not allowing `value == 0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Fixed
+
+-   [#270](https://github.com/equinor/webviz-core-components/pull/270) - Fixed bug in `Select `component not allowing value to be `0`.
+
 ## [0.6.0] - 2022-10-03
 
 ### Fixed

--- a/react/src/lib/components/Select/Select.stories.tsx
+++ b/react/src/lib/components/Select/Select.stories.tsx
@@ -40,8 +40,9 @@ const Template: ComponentStory<typeof Select> = (args) => {
 export const Basic = Template.bind({});
 Basic.args = {
     id: Select.defaultProps?.id || "select-component",
-    size: Select.defaultProps?.size || 5,
+    size: 6,
     options: [
+        { label: 0, value: 0 },
         { label: 1, value: 1 },
         { label: 2, value: 2 },
         { label: 3, value: 3 },

--- a/react/src/lib/components/Select/Select.tsx
+++ b/react/src/lib/components/Select/Select.tsx
@@ -223,14 +223,12 @@ export const Select: React.FC<InferProps<typeof propTypes>> = (
         >
             <select
                 value={
-                    selectedValues
-                        ? typeof selectedValues === "string" ||
-                          typeof selectedValues === "number"
-                            ? selectedValues
-                            : (selectedValues as (string | number)[]).map(
-                                  (el) => el.toString()
-                              )
-                        : ""
+                    typeof selectedValues === "string" ||
+                    typeof selectedValues === "number"
+                        ? selectedValues
+                        : (selectedValues as (string | number)[]).map((el) =>
+                              el.toString()
+                          )
                 }
                 multiple={multi}
                 size={size}

--- a/react/src/lib/components/Select/Select.tsx
+++ b/react/src/lib/components/Select/Select.tsx
@@ -225,7 +225,9 @@ export const Select: React.FC<InferProps<typeof propTypes>> = (
                 value={
                     typeof selectedValues === "string" ||
                     typeof selectedValues === "number"
-                        ? selectedValues
+                        ? multi
+                            ? [selectedValues.toString()]
+                            : selectedValues
                         : (selectedValues as (string | number)[]).map((el) =>
                               el.toString()
                           )


### PR DESCRIPTION
When setting the value of the `Select` component to `0` it would behave as if an invalid value was given. Since there is a default value anyways, no test for `undefined` is required. Removed unnecessary and false code.