### PR TITLE
Implemented check of stored active view and plugin ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -   [#270](https://github.com/equinor/webviz-core-components/pull/270) - Fixed bug in `Select `component not allowing value to be `0`.
+-   [#271](https://github.com/equinor/webviz-core-components/pull/271) - Invalid states for active plugin and view are now replaced with the first plugin of the current page and its first view.
 
 ## [0.6.0] - 2022-10-03
 

--- a/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
+++ b/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
@@ -491,19 +491,31 @@ export const WebvizContentManager: React.FC<WebvizContentManagerProps> = (
         }
 
         if (location.pathname !== lastLocation?.pathname && localState) {
+            const checkedActivePluginId = state.pluginsData.some(
+                (plugin) => plugin.id === localState.activePluginId
+            )
+                ? localState.activePluginId
+                : state.pluginsData[0].id;
+
+            const checkedActiveViewId = state.pluginsData.some((plugin) =>
+                plugin.views.some((view) => view.id === localState.activeViewId)
+            )
+                ? localState.activeViewId
+                : state.pluginsData[0].views[0].id;
+
             dispatch({
                 type: StoreActions.ApplyStoredLocalState,
                 payload: {
-                    pluginId: localState.activePluginId,
-                    viewId: localState.activeViewId,
+                    pluginId: checkedActivePluginId,
+                    viewId: checkedActiveViewId,
                     openSettingsGroupIds: localState.openSettingsGroupIds,
                 },
             });
 
             if (props.setProps) {
                 props.setProps({
-                    activeViewId: localState.activeViewId,
-                    activePluginId: localState.activePluginId,
+                    activeViewId: checkedActiveViewId,
+                    activePluginId: checkedActivePluginId,
                 });
             }
         } else {

--- a/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
+++ b/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
@@ -497,11 +497,13 @@ export const WebvizContentManager: React.FC<WebvizContentManagerProps> = (
                 ? localState.activePluginId
                 : state.pluginsData[0].id;
 
-            const checkedActiveViewId = state.pluginsData.some((plugin) =>
-                plugin.views.some((view) => view.id === localState.activeViewId)
-            )
+            const checkedActiveViewId = state.pluginsData
+                .find((plugin) => plugin.id === checkedActivePluginId)
+                ?.views.some((view) => view.id === localState.activeViewId)
                 ? localState.activeViewId
-                : state.pluginsData[0].views[0].id;
+                : state.pluginsData.find(
+                      (plugin) => plugin.id === checkedActivePluginId
+                  )?.views[0].id || "";
 
             dispatch({
                 type: StoreActions.ApplyStoredLocalState,

--- a/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
+++ b/react/src/lib/components/WebvizContentManager/WebvizContentManager.tsx
@@ -495,15 +495,15 @@ export const WebvizContentManager: React.FC<WebvizContentManagerProps> = (
                 (plugin) => plugin.id === localState.activePluginId
             )
                 ? localState.activePluginId
-                : state.pluginsData[0].id;
+                : state.pluginsData.at(0)?.id ?? "";
 
             const checkedActiveViewId = state.pluginsData
                 .find((plugin) => plugin.id === checkedActivePluginId)
                 ?.views.some((view) => view.id === localState.activeViewId)
                 ? localState.activeViewId
-                : state.pluginsData.find(
-                      (plugin) => plugin.id === checkedActivePluginId
-                  )?.views[0].id || "";
+                : state.pluginsData
+                      .find((plugin) => plugin.id === checkedActivePluginId)
+                      ?.views.at(0)?.id ?? "";
 
             dispatch({
                 type: StoreActions.ApplyStoredLocalState,


### PR DESCRIPTION
This should fix the issue with opening a page with an unselected plugin.

---
Potentially fixes https://github.com/equinor/webviz-config/issues/641.