### PR TITLE
Update workflow to remove `node 12` deprecation warnings in CI

### DIFF
--- a/.github/workflows/webviz-core-components.yml
+++ b/.github/workflows/webviz-core-components.yml
@@ -23,10 +23,10 @@ jobs:
 
         steps:
             - name: 📖 Checkout commit locally
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: 🐍 Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                   python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
In order to remove these:
![image](https://user-images.githubusercontent.com/31612826/203494289-1836937f-8a2b-4ea7-9022-1cb253b68486.png)
