### PR TITLE
Support Python 3.11 and 3.12

### DIFF
--- a/.github/workflows/webviz-core-components.yml
+++ b/.github/workflows/webviz-core-components.yml
@@ -19,16 +19,16 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                python-version: ["3.8", "3.9", "3.10"]
+                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
         steps:
             - name: 📖 Checkout commit locally
               uses: actions/checkout@v3
 
-            - name: 🐍 Set up Python ${{ matrix.python-version }}
+            - name: 🐍 Set up Python 3.8
               uses: actions/setup-python@v4
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: 3.8  # For compiling the JavaScript part we need dash<2.5, which is not supported on recent versions of Python
 
             - name: ℹ️ Node and npm versions
               run: |
@@ -49,6 +49,11 @@ jobs:
             - name: 🏗️ Build JavaScript part
               run: |
                   npm run build --prefix ./react
+
+            - name: 🐍 Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python-version }}
 
             - name: 📦 Install webviz-core-components with dependencies
               run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED] - YYYY-MM-DD
+## [0.7.0] - 2024-01-29
 
 ### Fixed
 
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -	[#275](https://github.com/equinor/webviz-core-components/pull/275) - Added `WebvizDialog` component. New dialog component which handles multiple instances simultaneously, where the currently active dialog is placed on top and highlighted with box shadow.
+-   [#299](https://github.com/equinor/webviz-core-components/pull/299) - Support Python 3.11 and 3.12.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/equinor/webviz-core-components.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/equinor/webviz-core-components/alerts/)
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/equinor/webviz-core-components.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/equinor/webviz-core-components/context:javascript)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/equinor/webviz-core-components.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/equinor/webviz-core-components/context:python)
-[![Python 3.8 | 3.9 | 3.10](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10-blue.svg)](https://www.python.org/)
+[![Python 3.8 | 3.9 | 3.10 | 3.11 | 3.12](https://img.shields.io/badge/python-3.8%20|%203.9%20|%203.10%20|%203.11%20|%203.12-blue.svg)](https://www.python.org/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black%20%28Python%29-000000.svg)](https://github.com/psf/black)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier%20%28JavaScript%29-ff69b4.svg)](https://github.com/prettier/prettier)
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRES = ["dash>=2.0"]
 
 TESTS_REQUIRE = [
     "bandit",
-    "black>=22.12",
+    "black>=22.12,<24",
     "dash[testing]",
     "flask<2.3",
     "pylint",

--- a/tests/test_color_scales.py
+++ b/tests/test_color_scales.py
@@ -27,4 +27,4 @@ def test_colorscale(dash_duo):
 
     dash_duo.start_server(app)
 
-    assert dash_duo.get_logs() == [], "browser console should contain no error"
+    assert dash_duo.get_logs() is None, "browser console should contain no error"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -42,4 +42,4 @@ def test_container_placeholder(dash_duo):
 
     dash_duo.start_server(app)
 
-    assert dash_duo.get_logs() == [], "browser console should contain no error"
+    assert dash_duo.get_logs() is None, "browser console should contain no error"

--- a/tests/test_plugin_placeholder.py
+++ b/tests/test_plugin_placeholder.py
@@ -25,4 +25,4 @@ def test_plugin_placeholder(dash_duo):
 
     dash_duo.start_server(app)
 
-    assert dash_duo.get_logs() == [], "browser console should contain no error"
+    assert dash_duo.get_logs() is None, "browser console should contain no error"


### PR DESCRIPTION
We extend the test suite to also include Python 3.11 and 3.12. Continue using Python 3.8 when building the JavaScript bundle (due to Dash upstream issue).