### PR TITLE
Pin react version to 18.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED] - YYYY-MM-DD
+
+### Changed
+-   [#304](https://github.com/equinor/webviz-core-components/pull/304) - Pinned `React` to version `18.2` in `package-lock.json` in order to comply with supported versions in `Dash`.
+
 ## [0.7.0] - 2024-01-29
 
 ### Changed

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -2181,31 +2181,31 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.6.8",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
-            "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+            "version": "1.6.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+            "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
             "dependencies": {
-                "@floating-ui/utils": "^0.2.8"
+                "@floating-ui/utils": "^0.2.9"
             }
         },
         "node_modules/@floating-ui/core/node_modules/@floating-ui/utils": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-            "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+            "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.6.12",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
-            "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+            "version": "1.6.13",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+            "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
             "dependencies": {
                 "@floating-ui/core": "^1.6.0",
-                "@floating-ui/utils": "^0.2.8"
+                "@floating-ui/utils": "^0.2.9"
             }
         },
         "node_modules/@floating-ui/dom/node_modules/@floating-ui/utils": {
-            "version": "0.2.8",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
-            "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+            "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
         },
         "node_modules/@floating-ui/react": {
             "version": "0.25.4",
@@ -3569,21 +3569,22 @@
             "dev": true
         },
         "node_modules/@types/react": {
-            "version": "18.3.17",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.17.tgz",
-            "integrity": "sha512-opAQ5no6LqJNo9TqnxBKsgnkIYHozW9KSTlFVoSUJYh1Fl/sswkEoqIugRSm7tbh6pABtYjGAjW+GOS23j8qbw==",
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
             "dependencies": {
                 "@types/prop-types": "*",
+                "@types/scheduler": "*",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.3.5",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-            "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
+            "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
             "dev": true,
-            "peerDependencies": {
-                "@types/react": "^18.0.0"
+            "dependencies": {
+                "@types/react": "*"
             }
         },
         "node_modules/@types/react-transition-group": {
@@ -3608,6 +3609,11 @@
             "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
             "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
             "dev": true
+        },
+        "node_modules/@types/scheduler": {
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
+            "integrity": "sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw=="
         },
         "node_modules/@types/send": {
             "version": "0.17.4",
@@ -12137,9 +12143,9 @@
             }
         },
         "node_modules/react": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -12183,15 +12189,15 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+            "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
             "dependencies": {
                 "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.2"
+                "scheduler": "^0.23.0"
             },
             "peerDependencies": {
-                "react": "^18.3.1"
+                "react": "^18.2.0"
             }
         },
         "node_modules/react-draggable": {

--- a/react/src/lib/components/Dialog/components/DialogComponent.tsx
+++ b/react/src/lib/components/Dialog/components/DialogComponent.tsx
@@ -126,7 +126,6 @@ export const DialogComponent: React.FC<DialogProps> = (props) => {
                         color: "#ccc",
                     }}
                 >
-                    { /* @ts-expect-error - this is a very weird bug */}
                     <Icon name="close" />
                 </IconButton>
             </DialogTitle>

--- a/react/src/lib/components/EdsIcon/EdsIcon.tsx
+++ b/react/src/lib/components/EdsIcon/EdsIcon.tsx
@@ -28,7 +28,6 @@ export const EdsIcon: React.FC<EdsIconProps> = (props) => {
                     `https://eds-storybook-react.azurewebsites.net/?path=/story/icons--preview.`
                 }
             >
-                { /* @ts-expect-error - this is a very weird bug */}
                 <Icon
                     id={props.id}
                     data={edsIcons.report}
@@ -42,7 +41,6 @@ export const EdsIcon: React.FC<EdsIconProps> = (props) => {
 
     return (
         <>
-        { /* @ts-expect-error - this is a very weird bug */}
         <Icon id={props.id} data={icon} size={props.size} color={props.color} />
         </>
     );

--- a/react/src/lib/components/Menu/components/Group/Group.tsx
+++ b/react/src/lib/components/Menu/components/Group/Group.tsx
@@ -73,7 +73,6 @@ export const Group: React.FC<GroupProps> = (props) => {
                             : "Collapse group"
                     }
                 >
-                    { /* @ts-expect-error - this is a very weird bug */}
                     <EdsIcon
                         name={
                             !collapsed || props.forceOpen

--- a/react/src/lib/components/Menu/components/Icon/Icon.tsx
+++ b/react/src/lib/components/Menu/components/Icon/Icon.tsx
@@ -27,7 +27,6 @@ export const Icon: React.FC<IconProps> = (props) => {
                     `https://eds-storybook-react.azurewebsites.net/?path=/story/icons--preview.`
                 }
             >
-                { /* @ts-expect-error - this is a very weird bug */}
                 <EdsIcon
                     data={edsIcons.report}
                     color="hsla(0, 100%, 50%, 1)"
@@ -39,7 +38,6 @@ export const Icon: React.FC<IconProps> = (props) => {
 
     return (
         <>
-        { /* @ts-expect-error - this is a very weird bug */}
         <EdsIcon
             data={icon}
             color={props.active ? "#FF1243" : "#989898"}

--- a/react/src/lib/components/Menu/components/MenuBar/MenuBar.tsx
+++ b/react/src/lib/components/Menu/components/MenuBar/MenuBar.tsx
@@ -331,7 +331,6 @@ export const MenuBar = React.forwardRef<HTMLDivElement, MenuBarProps>(
                         variant="ghost_icon"
                         onClick={handleMenuButtonClick}
                     >
-                        { /* @ts-expect-error - this is a very weird bug */}
                         <Icon name="menu" title="Open menu" />
                     </Button>
                 </div>

--- a/react/src/lib/components/WebvizDialog/components/WebvizDialogTitle/WebvizDialogTitle.tsx
+++ b/react/src/lib/components/WebvizDialog/components/WebvizDialogTitle/WebvizDialogTitle.tsx
@@ -74,7 +74,6 @@ export const WebvizDialogTitle = React.forwardRef<
                         aria-label="close"
                         onClick={() => handleCloseClick()}
                     >
-                        { /* @ts-expect-error - this is a very weird bug */}
                         <Icon name="close" />
                     </IconButton>
                 </div>

--- a/react/src/lib/components/WebvizPluginPlaceholder/components/WebvizContentOverlay.tsx
+++ b/react/src/lib/components/WebvizPluginPlaceholder/components/WebvizContentOverlay.tsx
@@ -43,14 +43,12 @@ const WebvizContentOverlay: React.FC<InferProps<typeof propTypes>> = ({
             <div className="webviz-plugin-data-owner">
                 {contactPerson && "name" in contactPerson && (
                     <p>
-                        { /* @ts-expect-error - this is a very weird bug */}
                         <Icon name="person" style={{ marginRight: "5px" }} />
                         {contactPerson.name}
                     </p>
                 )}
                 {contactPerson && "email" in contactPerson && (
                     <p>
-                        { /* @ts-expect-error - this is a very weird bug */}
                         <Icon name="email" style={{ marginRight: "5px" }} />
                         <a href="mailto:{this.props.contactPerson.email}">
                             {contactPerson.email}
@@ -59,7 +57,6 @@ const WebvizContentOverlay: React.FC<InferProps<typeof propTypes>> = ({
                 )}
                 {contactPerson && "phone" in contactPerson && (
                     <p>
-                        { /* @ts-expect-error - this is a very weird bug */}
                         <Icon name="call" style={{ marginRight: "5px" }} />
                         {contactPerson.phone}
                     </p>

--- a/react/src/lib/components/WebvizPluginPlaceholder/components/WebvizToolbarButton.tsx
+++ b/react/src/lib/components/WebvizPluginPlaceholder/components/WebvizToolbarButton.tsx
@@ -24,7 +24,6 @@ const WebvizToolbarButton: React.FC<WebvizToolbarButtonProps> = ({
     target,
 }) => {
     const createIcon = (useOnClick: boolean) => (
-        // @ts-expect-error - this is a very weird bug
         <Icon
             data={icon}
             className={classNames({

--- a/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
+++ b/react/src/lib/components/WebvizPluginTour/WebvizPluginTour.tsx
@@ -277,7 +277,6 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
                     >
                         {pluginData && (
                             <div className="WebvizPluginTour__View">
-                                { /* @ts-expect-error - this is a very weird bug */}
                                 <Icon name="view_carousel" />
                                 <span>
                                     {pluginData.views.find(
@@ -314,7 +313,6 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
                                         }
                                     >
                                         Next
-                                        { /* @ts-expect-error - this is a very weird bug */}
                                         <Icon name="arrow_forward" />
                                     </Button>
                                 }
@@ -329,7 +327,6 @@ export const WebvizPluginTour: React.FC<WebvizPluginTourProps> = (
                                         }}
                                         disabled={currentTourStep === 0}
                                     >
-                                        { /* @ts-expect-error - this is a very weird bug */}
                                         <Icon name="arrow_back" />
                                         Back
                                     </Button>

--- a/react/src/lib/components/WebvizPluginsWrapper/components/FullScreenMenu/full-screen-menu.tsx
+++ b/react/src/lib/components/WebvizPluginsWrapper/components/FullScreenMenu/full-screen-menu.tsx
@@ -38,7 +38,6 @@ export const FullScreenMenu: React.FC<FullScreenMenuProps> = (
                         }
                     >
                         <Tooltip title={action.tooltip}>
-                            { /* @ts-expect-error - this is a very weird bug */}
                             <>{icon && <Icon data={icon} />}</>
                         </Tooltip>
                     </IconButton>

--- a/react/src/lib/components/WebvizSettingsDrawer/WebvizSettingsDrawer.tsx
+++ b/react/src/lib/components/WebvizSettingsDrawer/WebvizSettingsDrawer.tsx
@@ -164,9 +164,7 @@ export const WebvizSettingsDrawer: React.FC<WebvizSettingsDrawerProps> = (
                             }`}
                             onClick={() => handleToggleOpenClick()}
                         >
-                            { /* @ts-expect-error - this is a very weird bug */}
                             <Icon name="chevron_left" />
-                            { /* @ts-expect-error - this is a very weird bug */}
                             <Icon name="settings" />
                         </Button>
                     </Tooltip>

--- a/react/src/lib/components/WebvizSettingsDrawer/components/AuthorDialog/author-dialog.tsx
+++ b/react/src/lib/components/WebvizSettingsDrawer/components/AuthorDialog/author-dialog.tsx
@@ -48,7 +48,7 @@ export const AuthorDialog: React.FC<AuthorDialogProps> = (
                         color: "#ccc",
                     }}
                 >
-                    { /* @ts-expect-error - this is a very weird bug */}
+                    
                     <Icon name="close" />
                 </IconButton>
             </DialogTitle>
@@ -57,7 +57,7 @@ export const AuthorDialog: React.FC<AuthorDialogProps> = (
                     <ListItem>
                         <ListItemAvatar>
                             <Avatar>
-                                { /* @ts-expect-error - this is a very weird bug */}
+                                
                                 <Icon name="person" />
                             </Avatar>
                         </ListItemAvatar>
@@ -66,7 +66,7 @@ export const AuthorDialog: React.FC<AuthorDialogProps> = (
                     <ListItem>
                         <ListItemAvatar>
                             <Avatar>
-                                { /* @ts-expect-error - this is a very weird bug */}
+                                
                                 <Icon name="email" />
                             </Avatar>
                         </ListItemAvatar>
@@ -75,7 +75,7 @@ export const AuthorDialog: React.FC<AuthorDialogProps> = (
                     <ListItem>
                         <ListItemAvatar>
                             <Avatar>
-                                { /* @ts-expect-error - this is a very weird bug */}
+                                
                                 <Icon name="phone" />
                             </Avatar>
                         </ListItemAvatar>

--- a/react/src/lib/components/WebvizSettingsDrawer/components/PluginActions/plugin-actions.tsx
+++ b/react/src/lib/components/WebvizSettingsDrawer/components/PluginActions/plugin-actions.tsx
@@ -563,7 +563,6 @@ export const PluginActions: React.FC<PluginActionsProps> = (
                 onClick={() => handleFullScreenClick()}
             >
                 <Tooltip title="Open active plugin in fullscreen mode">
-                    { /* @ts-expect-error - this is a very weird bug */}
                     <Icon name="fullscreen" />
                 </Tooltip>
             </div>
@@ -572,7 +571,6 @@ export const PluginActions: React.FC<PluginActionsProps> = (
                 onClick={() => handleScreenShotClick()}
             >
                 <Tooltip title="Take a screenshot from active plugin">
-                    { /* @ts-expect-error - this is a very weird bug */}
                     <Icon name="camera" />
                 </Tooltip>
             </div>
@@ -582,7 +580,6 @@ export const PluginActions: React.FC<PluginActionsProps> = (
                     onClick={handleDownloadClick}
                 >
                     <Tooltip title="Download data from active plugin">
-                        { /* @ts-expect-error - this is a very weird bug */}
                         <Icon name="download" />
                     </Tooltip>
                 </div>
@@ -599,7 +596,6 @@ export const PluginActions: React.FC<PluginActionsProps> = (
                             badgeContent={numDeprecationWarnings}
                             color="primary"
                         >
-                            { /* @ts-expect-error - this is a very weird bug */}
                             <Icon name="warning_outlined" />
                         </Badge>
                     </Tooltip>
@@ -611,7 +607,6 @@ export const PluginActions: React.FC<PluginActionsProps> = (
                     onClick={() => setOpenAuthorDialog(true)}
                 >
                     <Tooltip title="View active plugin's author">
-                        { /* @ts-expect-error - this is a very weird bug */}
                         <Icon name="person" />
                     </Tooltip>
                 </div>
@@ -622,7 +617,6 @@ export const PluginActions: React.FC<PluginActionsProps> = (
                     onClick={() => setTourIsOpen(true)}
                 >
                     <Tooltip title="Start a tour through the active plugin">
-                        { /* @ts-expect-error - this is a very weird bug */}
                         <Icon name="help" />
                     </Tooltip>
                 </div>
@@ -633,7 +627,6 @@ export const PluginActions: React.FC<PluginActionsProps> = (
                     onClick={() => openInNewTab(feedbackUrl)}
                 >
                     <Tooltip title="Report issue/give feedback on the active plugin">
-                        { /* @ts-expect-error - this is a very weird bug */}
                         <Icon name="comment_solid" />
                     </Tooltip>
                 </div>

--- a/react/src/lib/components/WebvizSettingsDrawer/components/ViewList/view-list.tsx
+++ b/react/src/lib/components/WebvizSettingsDrawer/components/ViewList/view-list.tsx
@@ -115,7 +115,6 @@ export const ViewList: React.FC<ViewListProps> = (props: ViewListProps) => {
                                     <div>
                                         {el.views[0].id ===
                                             props.activeViewId && (<>
-                                            { /* @ts-expect-error - this is a very weird bug */}
                                             <Icon name="check" />
                                             </>
                                         )}
@@ -153,7 +152,6 @@ export const ViewList: React.FC<ViewListProps> = (props: ViewListProps) => {
                                             <div>
                                                 {view.id ===
                                                     props.activeViewId && (<>
-                                                    { /* @ts-expect-error - this is a very weird bug */}
                                                     <Icon name="check" />
                                                     </>
                                                 )}

--- a/react/src/lib/components/WebvizSettingsDrawer/components/ViewSelector/view-selector.tsx
+++ b/react/src/lib/components/WebvizSettingsDrawer/components/ViewSelector/view-selector.tsx
@@ -146,7 +146,6 @@ export const ViewSelector: React.FC<ViewSelectorProps> = (
                 onClick={() => setMenuOpen(true)}
             >
                 <div ref={viewCarouselRef} className="WebvizViewSelector__Icon">
-                    { /* @ts-expect-error - this is a very weird bug */}
                     <Icon name="view_carousel" />
                 </div>
                 <div
@@ -165,7 +164,6 @@ export const ViewSelector: React.FC<ViewSelectorProps> = (
                         width: isCollapsed ? 0 : "auto",
                     }}
                 >
-                    { /* @ts-expect-error - this is a very weird bug */}
                     <Icon name="chevron_down" />
                 </div>
             </div>

--- a/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
+++ b/react/src/lib/components/WebvizSettingsGroup/WebvizSettingsGroup.tsx
@@ -148,7 +148,6 @@ export const WebvizSettingsGroup: React.FC<WebvizSettingsGroupProps> = (
                 >
                     {props.viewId === "" && (
                         <div className="WebvizSettingsGroup__GlobalIcon">
-                            { /* @ts-expect-error - this is a very weird bug */}
                             <Icon
                                 name="world"
                                 title="Global settings group"
@@ -162,7 +161,6 @@ export const WebvizSettingsGroup: React.FC<WebvizSettingsGroupProps> = (
                     {!props.alwaysOpen && (
                         <div>
                             <IconButton>
-                                { /* @ts-expect-error - this is a very weird bug */}
                                 <Icon
                                     name={
                                         props.open === true

--- a/react/src/lib/components/WebvizViewElement/WebvizViewElement.tsx
+++ b/react/src/lib/components/WebvizViewElement/WebvizViewElement.tsx
@@ -553,7 +553,6 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
                             <IconButton
                                 onClick={() => handleOpenSettingsDialog()}
                             >
-                                 { /* @ts-expect-error - this is a very weird bug */}
                                 <Icon name="settings" size={16} />
                             </IconButton>
                         </Tooltip>
@@ -564,7 +563,6 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
                     <div>
                         <Tooltip title="Download data from view element">
                             <IconButton onClick={() => handleDownloadClick()}>
-                                { /* @ts-expect-error - this is a very weird bug */}
                                 <Icon name="download" size={16} />
                             </IconButton>
                         </Tooltip>
@@ -573,7 +571,6 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
                 <div>
                     <Tooltip title="Take screenshot">
                         <IconButton onClick={handleScreenShotClick}>
-                            { /* @ts-expect-error - this is a very weird bug */}
                             <Icon name="camera" size={16} />
                         </IconButton>
                     </Tooltip>
@@ -581,7 +578,6 @@ export const WebvizViewElement: React.FC<WebvizViewElementProps> = (props) => {
                 <div>
                     <Tooltip title="View in fullscreen">
                         <IconButton onClick={handleFullScreenClick}>
-                            { /* @ts-expect-error - this is a very weird bug */}
                             <Icon name="fullscreen" size={16} />
                         </IconButton>
                     </Tooltip>


### PR DESCRIPTION
We have to pin React to version 18.2 since Dash is comparing the installed version with a list of supported versions. 18.2 is the newest one.

We are only pinning in `package-lock.json` as we are installing the package by using the `ci` command.