### PR TITLE
Disable Node.js package publishing in workflow

### DIFF
--- a/.github/workflows/webviz-core-components.yml
+++ b/.github/workflows/webviz-core-components.yml
@@ -81,17 +81,17 @@ jobs:
               if: github.event.release.prerelease
               run: echo "NPM_PUBLISH_TAG=next" >> $GITHUB_ENV
 
-            - name: 🔼 Build and publish Node.js package
-              if: github.event_name == 'release' && matrix.python-version == '3.8'
-              env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-              working-directory: ./react
-              run: |
-                  cp ../README.md .
-                  npm version --no-git-tag-version ${GITHUB_REF//refs\/tags\//}
-                  npm config set '//registry.npmjs.org/:_authToken' '${NPM_TOKEN}'
-                  # Use 'latest' tag if $NPM_PUBLISH_TAG is not set:
-                  npm publish --access public --tag ${NPM_PUBLISH_TAG:-latest}
+            # - name: 🔼 Build and publish Node.js package
+            #   if: github.event_name == 'release' && matrix.python-version == '3.8'
+            #   env:
+            #       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+            #   working-directory: ./react
+            #   run: |
+            #       cp ../README.md .
+            #       npm version --no-git-tag-version ${GITHUB_REF//refs\/tags\//}
+            #       npm config set '//registry.npmjs.org/:_authToken' '${NPM_TOKEN}'
+            #       # Use 'latest' tag if $NPM_PUBLISH_TAG is not set:
+            #       npm publish --access public --tag ${NPM_PUBLISH_TAG:-latest}
 
             - name: 🚢 Build and deploy Python package
               if: github.event_name == 'release' && matrix.python-version == '3.8'


### PR DESCRIPTION
As for now, we do not need new versions on `npm` of `wcc` while phasing out out (deprecated).